### PR TITLE
Add 512GB SD support, MS8607 support, Qwiic power control, I2C speed adjustment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,12 @@ Change Log
 v1.1
 ---------
 
-* Added support for exFat microSD cards. Tested up to 512GB. We still suppport smaller FAT16 and FAT32 formatted cards.
+* Add support for exFat microSD cards. Tested up to 512GB. Smaller FAT16 and FAT32 formatted cards are still supported.
+* Add support for MS8607 PHT sensor
+* Add ability to turn on/off power on Qwiic bus when time between sensor readings is > 2s. By default the bus powers down to save power but there may be instances where user wants to keep sensors powered up and running between reads. This can be accessed via the Attached Devices menu.
+* Add ability to limit I2C bus speed. Most devices operate at 400kHz I2C. Some (MCP9600) are automatically limited by OLA to 100kHz. There may be instances, because of bus length or other, where the user may want to artifically limit the bus speed. This can be access via the Attached Devices menu.
+
 
 v1.0
 ---------
-Initial release. Support for
-
-*
+Initial release.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,13 @@
+Change Log
+======================
+
+v1.1
+---------
+
+* Added support for exFat microSD cards. Tested up to 512GB. We still suppport smaller FAT16 and FAT32 formatted cards.
+
+v1.0
+---------
+Initial release. Support for
+
+*

--- a/Firmware/OpenLog_Artemis/OpenLog_Artemis.ino
+++ b/Firmware/OpenLog_Artemis/OpenLog_Artemis.ino
@@ -82,7 +82,7 @@ const int MAX_IDLE_TIME_MSEC = 500;
 bool newSerialData = false;
 char incomingBuffer[256 * 2]; //This size of this buffer is sensitive. Do not change without analysis using OpenLog_Serial.
 int incomingBufferSpot = 0;
-//int charsReceived = 0; //Used for verifying/debugging serial reception
+int charsReceived = 0; //Used for verifying/debugging serial reception
 //-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
 
 //Add ICM IMU interface
@@ -176,7 +176,7 @@ void setup() {
 
   Serial.flush(); //Complete any previous prints
   Serial.begin(settings.serialTerminalBaudRate);
-  Serial.printf("Artemis OpenLog v%f\n", FIRMWARE_VERSION);
+  Serial.printf("Artemis OpenLog v%.02f\n", FIRMWARE_VERSION);
 
   beginQwiic();
 
@@ -234,7 +234,7 @@ void loop() {
           serialDataFile.write(incomingBuffer, sizeof(incomingBuffer)); //Record the buffer to the card
           incomingBufferSpot = 0;
         }
-        //charsReceived++;
+        charsReceived++;
       }
 
       lastSeriaLogSyncTime = millis(); //Reset the last sync time to now
@@ -257,7 +257,7 @@ void loop() {
 
         newSerialData = false;
         lastSeriaLogSyncTime = millis(); //Reset the last sync time to now
-        //Serial.println("Total chars recevied: " + (String)charsReceived);
+        printDebug("Total chars received: " + (String)charsReceived);
       }
     }
   }
@@ -349,7 +349,7 @@ void beginSD()
       delay(250); //Give SD more time to power up, then try again
       if (sd.begin(SD_CONFIG) == false) //Slightly Faster SdFat Beta (we don't have dedicated SPI)
       {
-        Serial.println("SD init failed. Do you have the correct board selected in Arduino? Is card present? Formatted?");
+        Serial.println("SD init failed. Is card present? Formatted?");
         digitalWrite(PIN_MICROSD_CHIP_SELECT, HIGH); //Be sure SD is deselected
         online.microSD = false;
         return;

--- a/Firmware/OpenLog_Artemis/OpenLog_Artemis.ino
+++ b/Firmware/OpenLog_Artemis/OpenLog_Artemis.ino
@@ -33,7 +33,7 @@ enum returnStatus {
 
 //Setup Qwiic Port
 //-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
-#include "Wire.h"
+#include <Wire.h>
 TwoWire qwiic(1); //Will use pads 8/9
 const byte PIN_QWIIC_POWER = 18;
 //-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
@@ -137,6 +137,9 @@ SGP30 vocSensor_SGP30;
 
 #include "SparkFun_SCD30_Arduino_Library.h" //Click here to get the library: http://librarymanager/All#SparkFun_SCD30
 SCD30 co2Sensor_SCD30;
+
+#include "MS8607_Library.h" //Click here to get the library: http://librarymanager/All#Qwiic_MS8607
+MS8607 pressureSensor_MS8607;
 
 //-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
 

--- a/Firmware/OpenLog_Artemis/OpenLog_Artemis.ino
+++ b/Firmware/OpenLog_Artemis/OpenLog_Artemis.ino
@@ -17,7 +17,7 @@
 
 */
 
-const float FIRMWARE_VERSION = 1.0;
+const float FIRMWARE_VERSION = 1.1;
 
 #include "settings.h"
 
@@ -54,9 +54,16 @@ const byte PIN_MICROSD_POWER = 15; //x04
 #define SD_CONFIG SdSpiConfig(PIN_MICROSD_CHIP_SELECT, SHARED_SPI, SD_SCK_MHZ(24)) //Max of 24MHz
 #define SD_CONFIG_MAX_SPEED SdSpiConfig(PIN_MICROSD_CHIP_SELECT, DEDICATED_SPI, SD_SCK_MHZ(24)) //Max of 24MHz
 
-SdFat sd;
-File sensorDataFile; //File that all sensor data is written to
-File serialDataFile; //File that all incoming serial data is written to
+//ExFat
+SdFs sd;
+FsFile sensorDataFile; //File that all sensor data is written to
+FsFile serialDataFile; //File that all incoming serial data is written to
+
+//Fat16/32
+//SdFat sd;
+//File sensorDataFile; //File that all sensor data is written to
+//File serialDataFile; //File that all incoming serial data is written to
+
 char sensorDataFileName[30] = ""; //We keep a record of this file name so that we can re-open it upon wakeup from sleep
 char serialDataFileName[30] = ""; //We keep a record of this file name so that we can re-open it upon wakeup from sleep
 //-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-

--- a/Firmware/OpenLog_Artemis/Sensors.ino
+++ b/Firmware/OpenLog_Artemis/Sensors.ino
@@ -207,6 +207,26 @@ bool beginSensors()
     else
       beginSensorOutput += "SCD30 failed to respond. Check wiring.\n";
   }
+
+  if (qwiicAvailable.MS8607 && settings.sensor_MS8607.log && !qwiicOnline.MS8607)
+  {
+    if (pressureSensor_MS8607.begin(qwiic) == true) //Wire port. This checks both 0x40 and 0x76 sensor addresses
+    {
+      if(settings.sensor_MS8607.enableHeater == true)
+        pressureSensor_MS8607.enable_heater();
+      else
+        pressureSensor_MS8607.disable_heater();
+      
+      pressureSensor_MS8607.set_pressure_resolution(settings.sensor_MS8607.pressureResolution);
+      pressureSensor_MS8607.set_humidity_resolution(settings.sensor_MS8607.humidityResolution);
+
+      qwiicOnline.MS8607 = true;
+      beginSensorOutput += "MS8607 Online\n";
+    }
+    else
+      beginSensorOutput += "MS8607 failed to respond. Check wiring.\n";
+  }
+
   return true;
 }
 
@@ -638,6 +658,25 @@ void getData()
     if (settings.sensor_SCD30.logTemperature)
     {
       outputData += (String)co2Sensor_SCD30.getTemperature() + ",";
+      helperText += "degC,";
+    }
+  }
+
+  if (qwiicOnline.MS8607 && settings.sensor_MS8607.log)
+  {
+    if (settings.sensor_MS8607.logPressure)
+    {
+      outputData += (String)pressureSensor_MS8607.getPressure() + ",";
+      helperText += "hPa,";
+    }
+    if (settings.sensor_MS8607.logHumidity)
+    {
+      outputData += (String)pressureSensor_MS8607.getHumidity() + ",";
+      helperText += "humidity_%,";
+    }
+    if (settings.sensor_MS8607.logPressure)
+    {
+      outputData += (String)pressureSensor_MS8607.getTemperature() + ",";
       helperText += "degC,";
     }
   }

--- a/Firmware/OpenLog_Artemis/Sensors.ino
+++ b/Firmware/OpenLog_Artemis/Sensors.ino
@@ -716,5 +716,9 @@ void determineMaxI2CSpeed()
   else if (settings.sensor_uBlox.i2cSpeed == 100000)
     maxSpeed = 100000;
 
+  //If user wants to limit the I2C bus speed, do it here
+  if(maxSpeed > settings.qwiicBusMaxSpeed)
+    maxSpeed = settings.qwiicBusMaxSpeed;
+
   qwiic.setClock(maxSpeed);
 }

--- a/Firmware/OpenLog_Artemis/logging.ino
+++ b/Firmware/OpenLog_Artemis/logging.ino
@@ -25,7 +25,7 @@ char* findNextAvailableLog(int &newFileNumber, const char *fileLeader)
     if (sd.exists(newFileName) == false) break; //File name not found so we will use it.
 
     //File exists so open and see if it is empty. If so, use it.
-    newFile = sd.open(newFileName, O_READ);
+    newFile.open(newFileName, O_READ);
     if (newFile.size() == 0) break; // File is empty so we will use it.
 
     newFile.close(); // Close this existing file we just opened.

--- a/Firmware/OpenLog_Artemis/lowerPower.ino
+++ b/Firmware/OpenLog_Artemis/lowerPower.ino
@@ -114,9 +114,14 @@ void goToSleep()
     am_hal_gpio_pinconfig(x, g_AM_HAL_GPIO_DISABLE);
 
   //We can't leave these power control pins floating
-  qwiicPowerOff();
   imuPowerOff();
   microSDPowerOff();
+
+  //Keep Qwiic bus powered on if user desires it
+  if (settings.powerDownQwiicBusBetweenReads == true)
+    qwiicPowerOff();
+  else
+    qwiicPowerOn(); //Make sure pins stays as output
 
   //Power down Flash, SRAM, cache
   am_hal_pwrctrl_memory_deepsleep_powerdown(AM_HAL_PWRCTRL_MEM_CACHE); //Turn off CACHE

--- a/Firmware/OpenLog_Artemis/menuAttachedDevices.ino
+++ b/Firmware/OpenLog_Artemis/menuAttachedDevices.ino
@@ -103,6 +103,11 @@ void menuAttachedDevices()
       functionPointers[availableDevices - 1] = menuConfigure_SCD30;
       Serial.printf("%d) SCD30 CO2 Sensor\n", availableDevices++);
     }
+    if (qwiicAvailable.MS8607)
+    {
+      functionPointers[availableDevices - 1] = menuConfigure_MS8607;
+      Serial.printf("%d) MS8607 Pressure Humidity Temperature Sensor\n", availableDevices++);
+    }
 
     Serial.println("x) Exit");
 
@@ -155,6 +160,7 @@ bool detectQwiicDevices()
 #define ADR_VEML6075 0x10
 #define ADR_NAU7802 0x2A
 #define ADR_VL53L1X 0x29
+#define ADR_MS8607 0x40 //Humidity portion of the MS8607 sensor
 #define ADR_UBLOX 0x42
 #define ADR_TMP117 0x48 //Alternates: 0x49, 0x4A, and 0x4B
 #define ADR_SGP30 0x58
@@ -167,6 +173,7 @@ bool detectQwiicDevices()
 #define ADR_MCP9600_1 0x66
 #define ADR_BME280_2 0x76
 #define ADR_MS5637 0x76
+//#define ADR_MS8607 0x76 //Pressure portion of the MS8607 sensor. We'll catch the 0x40 first
 #define ADR_BME280_1 0x77
 
 //Given an address, see if it repsonds as we would expect
@@ -230,12 +237,22 @@ bool testDevice(uint8_t i2cAddress)
         qwiicAvailable.VEML6075 = true;
       break;
     case ADR_MS5637:
-      if (pressureSensor_MS5637.begin(qwiic) == true) //Wire port
-        qwiicAvailable.MS5637 = true;
-      break;
+      {
+        //By the time we hit this address, MS8607 should have already been started by its first address
+        if (qwiicAvailable.MS8607 == false)
+        {
+          if (pressureSensor_MS5637.begin(qwiic) == true) //Wire port
+            qwiicAvailable.MS5637 = true;
+        }
+        break;
+      }
     case ADR_SCD30:
       if (co2Sensor_SCD30.begin(qwiic) == true) //Wire port
         qwiicAvailable.SCD30 = true;
+      break;
+    case ADR_MS8607:
+      if (pressureSensor_MS8607.begin(qwiic) == true) //Wire port. Tests for both 0x40 and 0x76 I2C addresses.
+        qwiicAvailable.MS8607 = true;
       break;
     default:
       Serial.printf("Unknown device at address 0x%02X\n", i2cAddress);
@@ -1192,4 +1209,127 @@ void menuConfigure_SCD30()
   }
 
   qwiicOnline.SCD30 = false; //Mark as offline so it will be started with new settings
+}
+
+void menuConfigure_MS8607()
+{
+  while (1)
+  {
+    Serial.println();
+    Serial.println("Menu: Configure MS8607 Pressure Humidity Temperature (PHT) Sensor");
+
+    Serial.print("1) Sensor Logging: ");
+    if (settings.sensor_MS8607.log == true) Serial.println("Enabled");
+    else Serial.println("Disabled");
+
+    if (settings.sensor_MS8607.log == true)
+    {
+      Serial.print("2) Log Pressure: ");
+      if (settings.sensor_MS8607.logPressure == true) Serial.println("Enabled");
+      else Serial.println("Disabled");
+
+      Serial.print("3) Log Humidity: ");
+      if (settings.sensor_MS8607.logHumidity == true) Serial.println("Enabled");
+      else Serial.println("Disabled");
+
+      Serial.print("4) Log Temperature: ");
+      if (settings.sensor_MS8607.logTemperature == true) Serial.println("Enabled");
+      else Serial.println("Disabled");
+
+      Serial.print("5) Heater: ");
+      if (settings.sensor_MS8607.enableHeater == true) Serial.println("Enabled");
+      else Serial.println("Disabled");
+
+      Serial.print("6) Set Pressure Resolution: ");
+      if (settings.sensor_MS8607.pressureResolution == MS8607_pressure_resolution_osr_256)
+        Serial.print("0.11");
+      else if (settings.sensor_MS8607.pressureResolution == MS8607_pressure_resolution_osr_512)
+        Serial.print("0.062");
+      else if (settings.sensor_MS8607.pressureResolution == MS8607_pressure_resolution_osr_1024)
+        Serial.print("0.039");
+      else if (settings.sensor_MS8607.pressureResolution == MS8607_pressure_resolution_osr_2048)
+        Serial.print("0.028");
+      else if (settings.sensor_MS8607.pressureResolution == MS8607_pressure_resolution_osr_4096)
+        Serial.print("0.021");
+      else if (settings.sensor_MS8607.pressureResolution == MS8607_pressure_resolution_osr_8192)
+        Serial.print("0.016");
+      Serial.println(" mbar");
+
+      Serial.print("7) Set Humidity Resolution: ");
+      if (settings.sensor_MS8607.humidityResolution == MS8607_humidity_resolution_8b)
+        Serial.print("8");
+      else if (settings.sensor_MS8607.humidityResolution == MS8607_humidity_resolution_10b)
+        Serial.print("10");
+      else if (settings.sensor_MS8607.humidityResolution == MS8607_humidity_resolution_11b)
+        Serial.print("11");
+      else if (settings.sensor_MS8607.humidityResolution == MS8607_humidity_resolution_12b)
+        Serial.print("12");
+      Serial.println(" bits");
+    }
+    Serial.println("x) Exit");
+
+    byte incoming = getByteChoice(menuTimeout); //Timeout after x seconds
+
+    if (incoming == '1')
+      settings.sensor_MS8607.log ^= 1;
+    else if (settings.sensor_MS8607.log == true)
+    {
+      if (incoming == '2')
+        settings.sensor_MS8607.logPressure ^= 1;
+      else if (incoming == '3')
+        settings.sensor_MS8607.logHumidity ^= 1;
+      else if (incoming == '4')
+        settings.sensor_MS8607.logTemperature ^= 1;
+      else if (incoming == '5')
+        settings.sensor_MS8607.enableHeater ^= 1;
+      else if (incoming == '6')
+      {
+        Serial.println("Set Pressure Resolution:");
+        Serial.println("1) 0.11 mbar");
+        Serial.println("2) 0.062 mbar");
+        Serial.println("3) 0.039 mbar");
+        Serial.println("4) 0.028 mbar");
+        Serial.println("5) 0.021 mbar");
+        Serial.println("6) 0.016 mbar");
+        int amt = getNumber(menuTimeout); //x second timeout
+        if (amt >= 1 && amt <= 6)
+          settings.sensor_MS8607.pressureResolution = (MS8607_pressure_resolution)(amt - 1);
+        else
+          Serial.println("Error: Out of range");
+      }
+      else if (incoming == '7')
+      {
+        Serial.println("Set Humidity Resolution:");
+        Serial.println("1) 8 bit");
+        Serial.println("2) 10 bit");
+        Serial.println("3) 11 bit");
+        Serial.println("4) 12 bit");
+        int amt = getNumber(menuTimeout); //x second timeout
+        if (amt >= 1 && amt <= 4)
+        {
+          //Unfortunately these enums aren't sequential so we have to lookup
+          if (amt == 1) settings.sensor_MS8607.humidityResolution = MS8607_humidity_resolution_8b;
+          if (amt == 2) settings.sensor_MS8607.humidityResolution = MS8607_humidity_resolution_10b;
+          if (amt == 3) settings.sensor_MS8607.humidityResolution = MS8607_humidity_resolution_11b;
+          if (amt == 4) settings.sensor_MS8607.humidityResolution = MS8607_humidity_resolution_12b;
+        }
+        else
+          Serial.println("Error: Out of range");
+      }
+      else if (incoming == 'x')
+        break;
+      else if (incoming == STATUS_GETBYTE_TIMEOUT)
+        break;
+      else
+        printUnknown(incoming);
+    }
+    else if (incoming == 'x')
+      break;
+    else if (incoming == STATUS_GETBYTE_TIMEOUT)
+      break;
+    else
+      printUnknown(incoming);
+  }
+
+  qwiicOnline.MS8607 = false; //Mark as offline so it will be started with new settings
 }

--- a/Firmware/OpenLog_Artemis/menuDebug.ino
+++ b/Firmware/OpenLog_Artemis/menuDebug.ino
@@ -1,0 +1,27 @@
+void menuDebug()
+{
+  while (1)
+  {
+    Serial.println();
+    Serial.println("Menu: Configure Debug Settings");
+
+    Serial.print("1) Debug Messages: ");
+    if (settings.printDebugMessages == true) Serial.println("Enabled");
+    else Serial.println("Disabled");
+
+    Serial.println("x) Exit");
+
+    byte incoming = getByteChoice(menuTimeout); //Timeout after x seconds
+
+    if (incoming == '1')
+    {
+      settings.printDebugMessages ^= 1;
+    }
+    else if (incoming == 'x')
+      break;
+    else if (incoming == STATUS_GETBYTE_TIMEOUT)
+      break;
+    else
+      printUnknown(incoming);
+  }
+}

--- a/Firmware/OpenLog_Artemis/menuMain.ino
+++ b/Firmware/OpenLog_Artemis/menuMain.ino
@@ -23,10 +23,9 @@ void menuMain()
 
     Serial.println("6) Detect / Configure Attached Devices");
 
-    //Serial.println(") Configure Battery Voltage Logging");
-    //Enable VCC logging
-
     Serial.println("r) Reset all settings to default");
+
+    //Serial.println("d) Debug Menu");
 
     Serial.println("x) Return to logging");
 
@@ -45,12 +44,7 @@ void menuMain()
     else if (incoming == '6')
       menuAttachedDevices();
     else if (incoming == 'd')
-    {
-      Serial.print("Debug Messages ");
-      settings.printDebugMessages ^= 1;
-      if(settings.printDebugMessages == true) Serial.println("Enabled");
-      else Serial.println("Disabled");
-    }
+      menuDebug();
     else if (incoming == 'r')
     {
       Serial.println("\n\rResetting to factory defaults. Continue? Press 'y':");

--- a/Firmware/OpenLog_Artemis/menuMain.ino
+++ b/Firmware/OpenLog_Artemis/menuMain.ino
@@ -22,14 +22,7 @@ void menuMain()
     Serial.println("5) Configure Analog Pin Logging");
 
     Serial.println("6) Detect / Configure Attached Devices");
-    //Serial.println("1) Detect Qwiic Devices"); //Do this in sub menu
-    //If VL53L1X attached, set read distance, set read rate?
-    //Log internal temp sensor
-    //Set record freq
 
-    //Serial.println(") Configure Power Control");
-    //Power down ICM
-    //Turn off SD? RTC?...
     //Serial.println(") Configure Battery Voltage Logging");
     //Enable VCC logging
 
@@ -51,6 +44,13 @@ void menuMain()
       menuAnalogLogging();
     else if (incoming == '6')
       menuAttachedDevices();
+    else if (incoming == 'd')
+    {
+      Serial.print("Debug Messages ");
+      settings.printDebugMessages ^= 1;
+      if(settings.printDebugMessages == true) Serial.println("Enabled");
+      else Serial.println("Disabled");
+    }
     else if (incoming == 'r')
     {
       Serial.println("\n\rResetting to factory defaults. Continue? Press 'y':");

--- a/Firmware/OpenLog_Artemis/menuSerialLogging.ino
+++ b/Firmware/OpenLog_Artemis/menuSerialLogging.ino
@@ -47,9 +47,9 @@ void menuSerialLogging()
     {
       if (incoming == '2')
       {
-        Serial.print("Enter baud rate (1200 to 460800): ");
+        Serial.print("Enter baud rate (1200 to 921600): ");
         int newBaud = getNumber(menuTimeout); //Timeout after x seconds
-        if (newBaud < 1200 || newBaud > 460800)
+        if (newBaud < 1200 || newBaud > 921600)
         {
           Serial.println("Error: baud rate out of range");
         }

--- a/Firmware/OpenLog_Artemis/nvm.ino
+++ b/Firmware/OpenLog_Artemis/nvm.ino
@@ -90,6 +90,8 @@ void recordSettingsToFile()
     settingsFile.println("logAnalogVoltages=" + (String)settings.logAnalogVoltages);
     settingsFile.println("localUTCOffset=" + (String)settings.localUTCOffset);
     settingsFile.println("printDebugMessages=" + (String)settings.printDebugMessages);
+    settingsFile.println("powerDownQwiicBusBetweenReads=" + (String)settings.powerDownQwiicBusBetweenReads);
+    settingsFile.println("qwiicBusMaxSpeed=" + (String)settings.qwiicBusMaxSpeed);
     //    settingsFile.println("=" + (String)settings.sensor_LPS25HB.);
 
     settingsFile.close();
@@ -278,6 +280,10 @@ bool parseLine(char* str) {
     settings.localUTCOffset = d;
   else if (strcmp(settingName, "printDebugMessages") == 0)
     settings.printDebugMessages = d;
+  else if (strcmp(settingName, "powerDownQwiicBusBetweenReads") == 0)
+    settings.powerDownQwiicBusBetweenReads = d;
+  else if (strcmp(settingName, "qwiicBusMaxSpeed") == 0)
+    settings.qwiicBusMaxSpeed = d;
   //  else if (strcmp(settingName, "") == 0)
   //    settings. = d;
   else

--- a/Firmware/OpenLog_Artemis/nvm.ino
+++ b/Firmware/OpenLog_Artemis/nvm.ino
@@ -46,7 +46,7 @@ void recordSettingsToFile()
     if (sd.exists("OLA_settings.cfg"))
       sd.remove("OLA_settings.cfg");
 
-    File settingsFile;
+    FsFile settingsFile;
     if (settingsFile.open("OLA_settings.cfg", O_CREAT | O_APPEND | O_WRITE) == false)
     {
       Serial.println("Failed to create settings file");
@@ -105,7 +105,7 @@ bool loadSettingsFromFile()
   {
     if (sd.exists("OLA_settings.cfg"))
     {
-      File settingsFile;
+      FsFile settingsFile;
       if (settingsFile.open("OLA_settings.cfg", O_READ) == false)
       {
         Serial.println("Failed to open settings file");

--- a/Firmware/OpenLog_Artemis/settings.h
+++ b/Firmware/OpenLog_Artemis/settings.h
@@ -155,6 +155,7 @@ struct struct_settings {
   bool logA32 = false;
   bool logAnalogVoltages = true;
   int localUTCOffset = -7; //Default to Denver because we can
+  bool printDebugMessages = false;
   struct_LPS25HB sensor_LPS25HB;
   struct_uBlox sensor_uBlox;
   struct_VL53L1X sensor_VL53L1X;

--- a/Firmware/OpenLog_Artemis/settings.h
+++ b/Firmware/OpenLog_Artemis/settings.h
@@ -1,3 +1,5 @@
+#include "MS8607_Library.h" //Click here to get the library: http://librarymanager/All#Qwiic_MS8607
+
 //Add the new sensor settings below
 struct struct_LPS25HB {
   bool log = true;
@@ -115,6 +117,17 @@ struct struct_SCD30 {
   int temperatureOffset = 0; //C - Be careful not to overwrite the value on the sensor
 };
 
+
+struct struct_MS8607 {
+  bool log = true;
+  bool logHumidity = true;
+  bool logPressure = true;
+  bool logTemperature = true;
+  bool enableHeater = false; // The TE examples say that get_compensated_humidity and get_dew_point will only work if the heater is OFF
+  MS8607_pressure_resolution pressureResolution = MS8607_pressure_resolution_osr_8192; //17ms per reading, 0.016mbar resolution
+  MS8607_humidity_resolution humidityResolution = MS8607_humidity_resolution_12b; //12-bit
+};
+
 //This is all the settings that can be set on OpenLog. It's recorded to NVM and the config file.
 struct struct_settings {
   int sizeOfSettings = 0;
@@ -169,6 +182,7 @@ struct struct_settings {
   struct_VEML6075 sensor_VEML6075;
   struct_MS5637 sensor_MS5637;
   struct_SCD30 sensor_SCD30;
+  struct_MS8607 sensor_MS8607;
 } settings;
 
 //These are the devices on board OpenLog that may be on or offline.
@@ -195,6 +209,7 @@ struct struct_QwiicSensors {
   bool VEML6075;
   bool MS5637;
   bool SCD30;
+  bool MS8607;
 };
 
 struct_QwiicSensors qwiicAvailable = {
@@ -212,6 +227,7 @@ struct_QwiicSensors qwiicAvailable = {
   .VEML6075 = false,
   .MS5637 = false,
   .SCD30 = false,
+  .MS8607 = false,
 };
 
 struct_QwiicSensors qwiicOnline = {
@@ -229,4 +245,5 @@ struct_QwiicSensors qwiicOnline = {
   .VEML6075 = false,
   .MS5637 = false,
   .SCD30 = false,
+  .MS8607 = false,
 };

--- a/Firmware/OpenLog_Artemis/settings.h
+++ b/Firmware/OpenLog_Artemis/settings.h
@@ -169,6 +169,8 @@ struct struct_settings {
   bool logAnalogVoltages = true;
   int localUTCOffset = -7; //Default to Denver because we can
   bool printDebugMessages = false;
+  bool powerDownQwiicBusBetweenReads = true;
+  int qwiicBusMaxSpeed = 400000;
   struct_LPS25HB sensor_LPS25HB;
   struct_uBlox sensor_uBlox;
   struct_VL53L1X sensor_VL53L1X;

--- a/Firmware/OpenLog_Artemis/support.ino
+++ b/Firmware/OpenLog_Artemis/support.ino
@@ -1,3 +1,11 @@
+void printDebug(String thingToPrint)
+{
+  if(settings.printDebugMessages == true)
+  {
+    Serial.print(thingToPrint);    
+  }
+}
+
 
 //Option not known
 void printUnknown(uint8_t unknownChoice)

--- a/Firmware/Test Sketches/Sensor Autodetect/MS8607_Testing/MS8607_Testing.ino
+++ b/Firmware/Test Sketches/Sensor Autodetect/MS8607_Testing/MS8607_Testing.ino
@@ -1,0 +1,137 @@
+/*
+  Reading humidity from the MS8607
+  By: PaulZC
+  Date: January 28th, 2020
+
+  Based extensively on:
+  Reading barometric pressure from the MS5637
+  By: Nathan Seidle
+  SparkFun Electronics
+  License: MIT. See license file for more information but you can
+  basically do whatever you want with this code.
+
+  The original library and example code was written by TEConnectivity,
+  the company that made the sensor. Way to go TE! May other companies
+  learn from you.
+
+  Feel like supporting open source hardware?
+  Buy a board from SparkFun!
+
+  This example reads and displays the humidity and temperature from the MS8607.
+  It also displays the temperature-compensated humidity and the dew point.
+*/
+
+#include <Wire.h>
+
+#include <MS8607_Library.h>
+MS8607 barometricSensor;
+
+TwoWire qwiic(1); //Will use pads 8/9
+
+void setup(void) {
+  Serial.begin(115200);
+  Serial.println("Qwiic PHT Sensor MS8607 Example - Humidity");
+
+  const byte PIN_QWIIC_PWR = 18;
+  pinMode(PIN_QWIIC_PWR, OUTPUT);
+  digitalWrite(PIN_QWIIC_PWR, LOW); //qwiicPowerOn();
+  delay(10);
+  qwiic.begin();
+
+  if (barometricSensor.begin(qwiic) == false)
+  {
+    Serial.println("MS8607 sensor did not respond. Trying again...");
+    if (barometricSensor.begin() == false)
+    {
+      Serial.println("MS8607 sensor did not respond. Please check wiring.");
+      while(1)
+        ;
+    }
+  }
+
+  MS8607_pressure_resolution pressureResolution = MS8607_pressure_resolution_osr_8192; //17ms per reading, 0.016mbar resolution
+
+  //The sensor has 6 resolution levels. The higher the resolution the longer each
+  //reading takes to complete.
+//  barometricSensor.set_pressure_resolution(MS8607_pressure_resolution_osr_256); //1ms per reading, 0.11mbar resolution
+//  barometricSensor.set_pressure_resolution(MS8607_pressure_resolution_osr_512); //2ms per reading, 0.062mbar resolution
+//  barometricSensor.set_pressure_resolution(MS8607_pressure_resolution_osr_1024); //3ms per reading, 0.039mbar resolution
+//  barometricSensor.set_pressure_resolution(MS8607_pressure_resolution_osr_2048); //5ms per reading, 0.028mbar resolution
+//  barometricSensor.set_pressure_resolution(MS8607_pressure_resolution_osr_4096); //9ms per reading, 0.021mbar resolution
+  barometricSensor.set_pressure_resolution(pressureResolution); //17ms per reading, 0.016mbar resolution
+
+  // Example: set the humidity resolution
+  //int err = barometricSensor.set_humidity_resolution(MS8607_humidity_resolution_8b); // 8 bits
+  //int err = barometricSensor.set_humidity_resolution(MS8607_humidity_resolution_10b); // 10 bits
+  //int err = barometricSensor.set_humidity_resolution(MS8607_humidity_resolution_11b); // 11 bits
+  int err = barometricSensor.set_humidity_resolution(MS8607_humidity_resolution_12b); //12 bits
+  if (err != MS8607_status_ok)
+  {
+    Serial.print("Problem setting the MS8607 sensor humidity resolution. Error code = ");
+    Serial.println(err);
+    Serial.println("Freezing.");
+    while(1);
+  }
+  
+  // Turn the humidity sensor heater OFF
+  // The TE examples say that get_compensated_humidity and get_dew_point will only work if the heater is OFF
+  err = barometricSensor.disable_heater();
+  if (err != MS8607_status_ok)
+  {
+    Serial.print("Problem disabling the MS8607 humidity sensor heater. Error code = ");
+    Serial.println(err);
+    Serial.println("Freezing.");
+    while(1);
+  }
+}
+
+void loop(void) {
+
+  float humidity = barometricSensor.getHumidity();
+  float temperature = barometricSensor.getTemperature();
+  float pressure = barometricSensor.getPressure();
+
+  Serial.print("Humidity=");
+  Serial.print(humidity, 1);
+  Serial.print("(%RH)");
+
+  Serial.print(" Pressure=");
+  Serial.print(pressure, 3);
+  Serial.print("(hPa or mbar)");
+
+  Serial.print(" Temperature=");
+  Serial.print(temperature, 1);
+  Serial.print("(C)");
+
+//  float compensated_RH;
+//  int err = barometricSensor.get_compensated_humidity(temperature, humidity, &compensated_RH);
+//  if (err != MS8607_status_ok)
+//  {
+//    Serial.println();
+//    Serial.print("Problem getting the MS8607 compensated humidity. Error code = ");
+//    Serial.println(err);
+//    return;
+//  }
+  
+//  Serial.print(" Compensated humidity=");
+//  Serial.print(compensated_RH, 1);
+//  Serial.print("(%RH)");
+//  
+//  float dew_point;
+//  err = barometricSensor.get_dew_point(temperature, humidity, &dew_point);
+//  if (err != MS8607_status_ok)
+//  {
+//    Serial.println();
+//    Serial.print("Problem getting the MS8607 dew point. Error code = ");
+//    Serial.println(err);
+//    return;
+//  }
+//  
+//  Serial.print(" Dew point=");
+//  Serial.print(dew_point, 1);
+//  Serial.print("(C)");
+
+  Serial.println();
+
+  delay(10);
+}

--- a/Firmware/Test Sketches/Serial Logging/ConstantSerialBlastTest/ConstantSerialBlastTest.ino
+++ b/Firmware/Test Sketches/Serial Logging/ConstantSerialBlastTest/ConstantSerialBlastTest.ino
@@ -9,8 +9,6 @@ int testAmt = 3;
 //At 57600, testAmt of 10 takes about 1 minute, 40 takes about 5 minutes
 //At 115200, testAmt of 30 takes about 1 minute
 
-
-
 unsigned long startTime = 0;
 
 void setup()
@@ -18,15 +16,26 @@ void setup()
   pinMode(ledPin, OUTPUT);
 
   Serial.begin(115200);
+  Serial.println();
   Serial.println("Run OpenLog Test");
 
   int rate = 115200 * 4;
   Serial1.begin(rate);
-  Serial.print("Baud rate: ");
+
+  Serial.print("Current output baud rate: ");
   Serial.println(rate);
 
-  Serial1.print("Hello");
+  Serial.println("s)end test blob of text");
+  Serial.println("1)Set baud to 115200");
+  Serial.println("2)Set baud to 230400");
+  Serial.println("3)Set baud to 460800");
+  Serial.println("4)Set baud to 500000");
+  Serial.println("5)Set baud to 691200");
+  Serial.println("6)Set baud to 921600");
+  Serial.println("a)Increase blob size");
+  Serial.println("d)Decrease blob size");
 
+  //enableBurstMode(); //Go to 96MHz
 }
 
 void loop()
@@ -57,13 +66,18 @@ void loop()
     }
     else if (incoming == '4')
     {
-      Serial.println("Serial set to: 921600");
-      Serial1.begin(921600);
+      Serial.println("Serial set to: 500000");
+      Serial1.begin(500000);
     }
     else if (incoming == '5')
     {
-      Serial.println("Serial set to: 500000");
-      Serial1.begin(500000);
+      Serial.println("Serial set to: 691200");
+      Serial1.begin(691200);
+    }
+    else if (incoming == '6')
+    {
+      Serial.println("Serial set to: 921600");
+      Serial1.begin(921600);
     }
     else if (incoming == 'a')
     {
@@ -126,8 +140,11 @@ void sendBlob()
 
   unsigned long totalCharacters = (long)testAmt * 100 * 100;
   Serial.print("Characters pushed: ");
+  Serial.flush();
   Serial.println(totalCharacters);
   Serial.print("Time taken (s): ");
+  Serial.flush();
   Serial.println((millis() - startTime) / 1000.0, 2);
   Serial.println("Done!");
+  Serial.flush();
 }

--- a/Firmware/Test Sketches/Serial Logging/OpenLog_Bare_Serial/OpenLog_Bare_Serial.ino
+++ b/Firmware/Test Sketches/Serial Logging/OpenLog_Bare_Serial/OpenLog_Bare_Serial.ino
@@ -1,8 +1,11 @@
 /*
   October 11th, 2019
-
-  Increase local serial, turn off except when syncing
-  Try better grade card
+  
+  A stripped down sketch to test the reception of different speeds of serial
+  and recording them to an SD card. Use with another board (RedBoard Artemis) 
+  and the ConstantSerialBlastTest.ino to send blocks of text. This sketch
+  will output the # of bytes received so you can quickly see if all 30,000
+  bytes made it over or if bytes were dropped.
 
   460800bps = 2.17 * 10^-6 or 2.17us per bit
   10 bits to the byte so 21.7us per byte
@@ -11,25 +14,29 @@
   16384 buffer size will allow for up to 355.532ms before bytes are dropped
   4096 buffer size will allow for up to 88.75ms before bytes are dropped
 
-  How big is RX FIFO within HAL? 32 bytes
-  Is there a 'nearly full' interrupt for the RX FIFO?
-  We could check the RX FIFO empty bit in the ISR in a loop
-  We could increase the ISR priority level
-
   ISR is currently 16us which supports 460800. We can burst mode to 8.5us.
+
+  With the most recent pull of the Apollo3 core from Github (ISR reduced, buffers
+  increased to 4096), and a 512GB card, this sketch can correctly receive/store
+  non-stop serial at 500000bps. Burst mode is not needed.
+
+  691200bps is possible in burst mode
   
 */
 
 //microSD Interface
 //-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
 #include <SPI.h>
-#include <SdFat.h> //We do not use the built-in SD.h file because it calls Serial.print
+#include <SdFat.h>
 
 const byte PIN_MICROSD_CHIP_SELECT = 10;
 const byte PIN_MICROSD_POWER = 15; //x04
 
-SdFat sd;
-SdFile serialDataFile; //Record all incoming serial to this file
+SdFs sd; //exFat Support
+FsFile serialDataFile; //Record all incoming serial to this file
+
+//SdFat sd;
+//SdFile serialDataFile; //Record all incoming serial to this file
 //-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
 
 long overallStartTime; //Used to calc the actual update rate.
@@ -100,6 +107,16 @@ void setup() {
 
   overallStartTime = millis();
   //enableBurstMode(); //Go to 96MHz
+
+  Serial.println("1)Set baud to 115200");
+  Serial.println("2)Set baud to 230400");
+  Serial.println("3)Set baud to 460800");
+  Serial.println("4)Set baud to 500000");
+  Serial.println("5)Set baud to 691200");
+  Serial.println("6)Set baud to 921600");
+  Serial.println("r)reset count");
+  Serial.println("b)Enable Burst Mode");
+  Serial.println("d)Disable Burst Mode");
 }
 
 void loop()
@@ -115,7 +132,6 @@ void loop()
         serialDataFile.write(incomingBuffer, sizeof(incomingBuffer)); //Record the buffer to the card
         incomingBufferSpot = 0;
       }
-
       charsReceived++;
     }
     lastSeriaLogSyncTime = millis();
@@ -162,18 +178,33 @@ void loop()
     }
     else if (incoming == '4')
     {
-      Serial.println("Serial set to: 921600");
-      SerialLog.begin(921600);
+      Serial.println("Serial set to: 500000");
+      SerialLog.begin(500000);
     }
     else if (incoming == '5')
     {
-      Serial.println("Serial set to: 500000");
-      SerialLog.begin(500000);
+      Serial.println("Serial set to: 691200");
+      SerialLog.begin(691200);
+    }
+    else if (incoming == '6')
+    {
+      Serial.println("Serial set to: 921600");
+      SerialLog.begin(921600);
     }
     else if (incoming == 'r')
     {
       Serial.println("Total count reset");
       charsReceived = 0;
+    }
+    else if (incoming == 'e')
+    {
+      Serial.println("Burst mode enabled");
+      enableBurstMode(); //Go to 96MHz
+    }
+    else if (incoming == 'd')
+    {
+      Serial.println("Burst mode disabled");
+      disableBurstMode(); //Go to 48MHz
     }
     else if (incoming == '\r' || incoming == '\n')
     {


### PR DESCRIPTION
* Add support for exFat microSD cards. Tested up to 512GB. Smaller FAT16 and FAT32 formatted cards are still supported.
* Add support for MS8607 PHT sensor
* Add ability to turn on/off power on Qwiic bus when time between sensor readings is > 2s. By default the bus powers down to save power but there may be instances where user wants to keep sensors powered up and running between reads. This can be accessed via the Attached Devices menu.
* Add ability to limit I2C bus speed. Most devices operate at 400kHz I2C. Some (MCP9600) are automatically limited by OLA to 100kHz. There may be instances, because of bus length or other, where the user may want to artifically limit the bus speed. This can be access via the Attached Devices menu.
