### PR TITLE
Update lowerPower.ino

### DIFF
--- a/Firmware/OpenLog_Artemis/lowerPower.ino
+++ b/Firmware/OpenLog_Artemis/lowerPower.ino
@@ -28,7 +28,7 @@ void powerDown()
   power_adc_disable(); //Power down ADC. It it started by default before setup().
 
   Serial.end(); //Power down UART
-  Serial1.end();
+  SerialLog.end();
 
   //Force the peripherals off
   am_hal_pwrctrl_periph_disable(AM_HAL_PWRCTRL_PERIPH_IOM0);
@@ -95,7 +95,7 @@ void goToSleep()
   power_adc_disable(); //Power down ADC. It it started by default before setup().
 
   Serial.end(); //Power down UART
-  Serial1.end();
+  SerialLog.end();
 
   //Force the peripherals off
   am_hal_pwrctrl_periph_disable(AM_HAL_PWRCTRL_PERIPH_IOM0);


### PR DESCRIPTION
Hi @nseidle,

Super tiny PR. In **lowerPower.ino** there are two instances of `Serial1` that should be renamed `SerialLog`. They also prevent **OpenLog_Artemis.ino** from compiling properly.

Cheers,
Adam