### PR TITLE
PlatformIO?

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,10 @@ Icon
 # Files that might appear on external disk
 .Spotlight-V100
 .Trashes
+
+# PlatformIO
+.pio
+CMakeListsPrivate.txt
+cmake-build-*/
+
+

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,33 @@
+# !!! WARNING !!! AUTO-GENERATED FILE, PLEASE DO NOT MODIFY IT AND USE
+# https://docs.platformio.org/page/projectconf/section_env_build.html#build-flags
+#
+# If you need to override existing CMake configuration or add extra,
+# please create `CMakeListsUser.txt` in the root of project.
+# The `CMakeListsUser.txt` will not be overwritten by PlatformIO.
+
+cmake_minimum_required(VERSION 3.13)
+set(CMAKE_SYSTEM_NAME Generic)
+set(CMAKE_C_COMPILER_WORKS 1)
+set(CMAKE_CXX_COMPILER_WORKS 1)
+
+project("OpenLog_Artemis" C CXX)
+
+include(CMakeListsPrivate.txt)
+
+if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/CMakeListsUser.txt)
+include(CMakeListsUser.txt)
+endif()
+
+add_custom_target(
+    Production ALL
+    COMMAND platformio -c clion run "$<$<NOT:$<CONFIG:All>>:-e${CMAKE_BUILD_TYPE}>"
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+)
+
+add_custom_target(
+    Debug ALL
+    COMMAND platformio -c clion run --target debug "$<$<NOT:$<CONFIG:All>>:-e${CMAKE_BUILD_TYPE}>"
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+)
+
+add_executable(Z_DUMMY_TARGET ${SRC_LIST})

--- a/Firmware/OpenLog_Artemis/OpenLog_Artemis.ino
+++ b/Firmware/OpenLog_Artemis/OpenLog_Artemis.ino
@@ -1556,9 +1556,9 @@ void beginSerialOutput()
 
 void updateDataFileCreate(SdFileType *dataFile)
 {
-    myRTC.getTime(); //Get the RTC time so we can use it to update the create time
-    //Update the file create time
-    dataFile->timestamp(T_CREATE, (myRTC.year + 2000), myRTC.month, myRTC.dayOfMonth, myRTC.hour, myRTC.minute, myRTC.seconds);
+  myRTC.getTime(); //Get the RTC time so we can use it to update the create time
+  //Update the file create time
+  dataFile->timestamp(T_CREATE, (myRTC.year + 2000), myRTC.month, myRTC.dayOfMonth, myRTC.hour, myRTC.minute, myRTC.seconds);
 }
 
 void updateDataFileAccess(SdFileType *dataFile)

--- a/Firmware/OpenLog_Artemis/OpenLog_Artemis.ino
+++ b/Firmware/OpenLog_Artemis/OpenLog_Artemis.ino
@@ -196,22 +196,22 @@ TwoWire qwiic(PIN_QWIIC_SDA,PIN_QWIIC_SCL); //Will use pads 8/9
 #define SD_CONFIG SdSpiConfig(PIN_MICROSD_CHIP_SELECT, SHARED_SPI, SD_SCK_MHZ(24)) // 24MHz
 
 #if SD_FAT_TYPE == 1
-SdFat32 sd;
-File32 sensorDataFile; //File that all sensor data is written to
-File32 serialDataFile; //File that all incoming serial data is written to
+typedef SdFat32 SdFileSystemType;
+typedef File32 SdFileType;
 #elif SD_FAT_TYPE == 2
-SdExFat sd;
-ExFile sensorDataFile; //File that all sensor data is written to
-ExFile serialDataFile; //File that all incoming serial data is written to
+typedef SdExFat SdFileSystemType;
+typedef ExFile SdFileType;
 #elif SD_FAT_TYPE == 3
-SdFs sd;
-FsFile sensorDataFile; //File that all sensor data is written to
-FsFile serialDataFile; //File that all incoming serial data is written to
+typedef SdFs SdFileSystemType;
+typedef FsFile SdFileType;
 #else // SD_FAT_TYPE == 0
-SdFat sd;
-File sensorDataFile; //File that all sensor data is written to
-File serialDataFile; //File that all incoming serial data is written to
+typedef SdFat SdFileSystemType;
+typedef File SdFileType;
 #endif  // SD_FAT_TYPE
+
+SdFileSystemType sd;
+SdFileType sensorDataFile; //File that all sensor data is written to
+SdFileType serialDataFile; //File that all incoming serial data is written to
 
 //#define PRINT_LAST_WRITE_TIME // Uncomment this line to enable the 'measure the time between writes' diagnostic
 
@@ -1554,30 +1554,14 @@ void beginSerialOutput()
     online.serialOutput = false;
 }
 
-#if SD_FAT_TYPE == 1
-void updateDataFileCreate(File32 *dataFile)
-#elif SD_FAT_TYPE == 2
-void updateDataFileCreate(ExFile *dataFile)
-#elif SD_FAT_TYPE == 3
-void updateDataFileCreate(FsFile *dataFile)
-#else // SD_FAT_TYPE == 0
-void updateDataFileCreate(File *dataFile)
-#endif  // SD_FAT_TYPE
+void updateDataFileCreate(SdFileType *dataFile)
 {
-  myRTC.getTime(); //Get the RTC time so we can use it to update the create time
-  //Update the file create time
-  dataFile->timestamp(T_CREATE, (myRTC.year + 2000), myRTC.month, myRTC.dayOfMonth, myRTC.hour, myRTC.minute, myRTC.seconds);
+    myRTC.getTime(); //Get the RTC time so we can use it to update the create time
+    //Update the file create time
+    dataFile->timestamp(T_CREATE, (myRTC.year + 2000), myRTC.month, myRTC.dayOfMonth, myRTC.hour, myRTC.minute, myRTC.seconds);
 }
 
-#if SD_FAT_TYPE == 1
-void updateDataFileAccess(File32 *dataFile)
-#elif SD_FAT_TYPE == 2
-void updateDataFileAccess(ExFile *dataFile)
-#elif SD_FAT_TYPE == 3
-void updateDataFileAccess(FsFile *dataFile)
-#else // SD_FAT_TYPE == 0
-void updateDataFileAccess(File *dataFile)
-#endif  // SD_FAT_TYPE
+void updateDataFileAccess(SdFileType *dataFile)
 {
   myRTC.getTime(); //Get the RTC time so we can use it to update the last modified time
   //Update the file access time

--- a/PIO_SETUP.md
+++ b/PIO_SETUP.md
@@ -1,0 +1,26 @@
+##Why switch to PlatformIO?
+- You won't need to install the 20+ Arduino dependencies manually!
+- Specify build flags like `ICM_20948_USE_DMP` in the platformio.ini instead of modifying library headers
+- Use fixed version numbers for dependencies so your project won't break when a library updates
+- It's optional to use; you can switch back to the Arduino IDE with no additional configuration
+- Compiles the firmware much faster than the Arduino IDE
+
+
+## Setup for Development with PlatformIO
+
+- Install PlatformIO Core: [https://platformio.org/install](https://platformio.org/install)
+- Follow these directions to install the apollo3blue platform: [https://github.com/nigelb/platform-apollo3blue#install](https://github.com/nigelb/platform-apollo3blue#install)
+  - You might need to create the packages and platforms folders if they don't exist:
+    - `mkdir ~/.platformio/packages`
+    - `mkdir ~/.platformio/platforms`
+
+## Build and Upload
+
+Open the project in any [PlatformIO compatible IDE](https://platformio.org/install/integration) and upload the firmware to your OLA.
+
+Or, you could upload to the OLA using the command line: (make sure to [install the pio shell commands first](https://docs.platformio.org/en/latest//core/installation.html#install-shell-commands))
+- `cd <repo location on your computer>/OpenLog_Artemis`
+- `pio run`
+- Then, use the Arduino IDE serial monitor like usual, or run `pio device monitor -p 115200` to test the firmware!
+
+See [https://docs.platformio.org/en/latest/what-is-platformio.html](https://docs.platformio.org/en/latest/what-is-platformio.html) for more information.

--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ Documentation
 * **[UPGRADE.md](./UPGRADE.md)** - contains full instructions on how to upgrade the firmware on the OLA using the [Artemis Firmware Upload GUI](https://github.com/sparkfun/Artemis-Firmware-Upload-GUI).
 * **[CONTRIBUTING.md](./CONTRIBUTING.md)** - guidance on how to contribute to this library.
 * **[Installing an Arduino Library Guide](https://learn.sparkfun.com/tutorials/installing-an-arduino-library)** - OLA includes a large number of libraries that will need to be installed before compiling will work.
+* **[PIO_SETUP.md](./PIO_SETUP.md)** - contains instructions on how to automatically download all dependencies and compile the OLA firmware with PlatformIO
 * **[ADDING_SENSORS.md](./ADDING_SENSORS.md)** - contains _abbreviated_ instructions on how to add a new sensor to the OLA firmware. It's more of an aide-memoire really... Sorry about that.
 * **[SENSOR_UNITS.md](./SENSOR_UNITS.md)** - contains a summary of the units used for each sensor measurement.
 

--- a/platformio.ini
+++ b/platformio.ini
@@ -1,0 +1,54 @@
+; PlatformIO Project Configuration File
+;
+;   Build options: build flags, source filter
+;   Upload options: custom upload port, speed and extra flags
+;   Library options: dependencies, extra library storages
+;   Advanced options: extra scripting
+;
+; Please visit documentation for the other options and examples
+; https://docs.platformio.org/page/projectconf.html
+
+[platformio]
+src_dir = Firmware/OpenLog_Artemis
+
+[env:SparkFun_RedBoard_Artemis_ATP]
+platform = apollo3blue
+board = SparkFun_RedBoard_Artemis_ATP
+framework = arduino
+upload_speed = 460800
+monitor_speed = 115200
+;monitor_speed = 500000
+platform_packages =
+	framework-arduinoapollo3@2.1.0
+;	platformio/toolchain-gccarmnoneeabi@1.80201.181220
+	platformio/toolchain-gccarmnoneeabi@1.90201.191206
+build_flags = -D ICM_20948_USE_DMP
+lib_deps = 
+	greiman/SdFat
+	https://github.com/sparkfun/SparkFun_ICM-20948_ArduinoLibrary.git#5ee49bcdf155a439f1184d2fcda1f6ffe51f9af7
+	sparkfun/SparkFun I2C Mux Arduino Library@^1.0.2
+	sparkfun/SparkFun CCS811 Arduino Library@^2.0.1
+	sparkfun/SparkFun VL53L1X 4m Laser Distance Sensor@^1.2.9
+	sparkfun/SparkFun BME280@^2.0.9
+	sparkfun/SparkFun LPS25HB Pressure Sensor Library@^1.1.0
+	sparkfun/SparkFun VEML6075 Arduino Library@^1.1.4
+	sparkfun/SparkFun PHT MS8607 Arduino Library@^1.0.3
+	sparkfun/SparkFun MCP9600 Thermocouple Library@^1.0.4
+	sparkfun/SparkFun SGP30 Arduino Library@^1.0.5
+	sparkfun/SparkFun VCNL4040 Proximity Sensor Library@^1.0.2
+	sparkfun/SparkFun MS5637 Barometric Pressure Library@^1.0.1
+	sparkfun/SparkFun High Precision Temperature Sensor TMP117 Qwiic@^1.2.3
+	sparkfun/SparkFun u-blox GNSS Arduino Library@^2.0.15
+	sparkfun/SparkFun Qwiic Scale NAU7802 Arduino Library@^1.0.4
+	sparkfun/SparkFun SCD30 Arduino Library@^1.0.14
+	sparkfun/SparkFun Qwiic Humidity AHT20@^1.0.1
+	sparkfun/SparkFun SHTC3 Humidity and Temperature Sensor Library@^1.1.3
+	sparkfun/SparkFun ADS122C04 ADC Arduino Library@^1.0.2
+	sparkfun/SparkFun MicroPressure Library@^1.0.1
+	sparkfun/SparkFun Particle Sensor Panasonic SN-GCJA5@^1.0.1
+	sparkfun/SparkFun SGP40 Arduino Library@^1.0.2
+	sparkfun/SparkFun SDP3x Arduino Library@^1.0.2
+	sparkfun/SparkFun Qwiic Button and Qwiic Switch Library@^2.0.5
+	https://github.com/sparkfunX/BlueRobotics_MS5837_Library#2399b3b
+	sparkfun/SparkFun Bio Sensor Hub Library@^1.0.5
+	arduino-libraries/ArduinoBLE@^1.2.1


### PR DESCRIPTION
Have you considered using [platformio](https://platformio.org/) to manage dependencies for development?
- You won't need to install the 20+ Arduino dependencies manually
- You can specify build flags like `ICM_20948_USE_DMP` in the platformio.ini instead of modifying library headers
- You can use any IDE (vscode, clion, etc.), not just the Arduino IDE
- No changes to the project structure or the code*, you would just need a platformio.ini and CMakeLists.txt
- Anyone can still use the code in the Arduino IDE, doesn't break compatibility

(*I did need to modify the SD_FAT_TYPE switching to use typedefs to get the firmware to compile on my machine)

It is a bit trickier to install platformio than the Arduino IDE but I've found it's worth the trouble once it's set up.