### PR TITLE
Add support for BMP390

### DIFF
--- a/Firmware/OpenLog_Artemis/OpenLog_Artemis.ino
+++ b/Firmware/OpenLog_Artemis/OpenLog_Artemis.ino
@@ -289,6 +289,7 @@ icm_20948_DMP_data_t dmpData; // Global storage for the DMP data - extracted fro
 #include "SparkFunCCS811.h" //Click here to get the library: http://librarymanager/All#SparkFun_CCS811
 #include "SparkFun_VL53L1X.h" //Click here to get the library: http://librarymanager/All#SparkFun_VL53L1X
 #include "SparkFunBME280.h" //Click here to get the library: http://librarymanager/All#SparkFun_BME280
+#include "DFRobot_BMP390.h" //Click here to get the library: http://librarymanager/All#DFRobot_BMP390
 #include "SparkFun_LPS25HB_Arduino_Library.h"  //Click here to get the library: http://librarymanager/All#SparkFun_LPS25HB
 #include "SparkFun_VEML6075_Arduino_Library.h" //Click here to get the library: http://librarymanager/All#SparkFun_VEML6075
 #include "SparkFun_PHT_MS8607_Arduino_Library.h" //Click here to get the library: http://librarymanager/All#SparkFun_PHT_MS8607

--- a/Firmware/OpenLog_Artemis/OpenLog_Artemis.ino
+++ b/Firmware/OpenLog_Artemis/OpenLog_Artemis.ino
@@ -289,7 +289,7 @@ icm_20948_DMP_data_t dmpData; // Global storage for the DMP data - extracted fro
 #include "SparkFunCCS811.h" //Click here to get the library: http://librarymanager/All#SparkFun_CCS811
 #include "SparkFun_VL53L1X.h" //Click here to get the library: http://librarymanager/All#SparkFun_VL53L1X
 #include "SparkFunBME280.h" //Click here to get the library: http://librarymanager/All#SparkFun_BME280
-#include "DFRobot_BMP390.h" //Click here to get the library: http://librarymanager/All#DFRobot_BMP390
+#include "DFRobot_BMP3XX.h" //Click here to get the library: http://librarymanager/All#DFRobot_BMP3XX
 #include "SparkFun_LPS25HB_Arduino_Library.h"  //Click here to get the library: http://librarymanager/All#SparkFun_LPS25HB
 #include "SparkFun_VEML6075_Arduino_Library.h" //Click here to get the library: http://librarymanager/All#SparkFun_VEML6075
 #include "SparkFun_PHT_MS8607_Arduino_Library.h" //Click here to get the library: http://librarymanager/All#SparkFun_PHT_MS8607

--- a/Firmware/OpenLog_Artemis/Sensors.ino
+++ b/Firmware/OpenLog_Artemis/Sensors.ino
@@ -491,6 +491,33 @@ void gatherDeviceValues(char * outputData, size_t lenData)
             }
           }
           break;
+        case DEVICE_PRESSURE_BMP390:
+          {
+            DFRobot_BMP390L_I2C *nodeDevice = (DFRobot_BMP390L_I2C *)temp->classPtr;
+            struct_BMP390 *nodeSetting = (struct_BMP390 *)temp->configPtr;
+            if (nodeSetting->log == true)
+            {
+              if (nodeSetting->logPressure)
+              {
+                olaftoa(nodeDevice->readPressPa(), tempData1, 2, sizeof(tempData) / sizeof(char));
+                sprintf(tempData, "%s,", tempData1);
+                strlcat(outputData, tempData, lenData);
+              }
+              if (nodeSetting->logAltitude)
+              {
+                olaftoa(nodeDevice->readAltitudeM(), tempData1, 2, sizeof(tempData) / sizeof(char));
+                sprintf(tempData, "%s,", tempData1);
+                strlcat(outputData, tempData, lenData);
+              }
+              if (nodeSetting->logTemperature)
+              {
+                olaftoa(nodeDevice->readTempC(), tempData1, 2, sizeof(tempData) / sizeof(char));
+                sprintf(tempData, "%s,", tempData1);
+                strlcat(outputData, tempData, lenData);
+              }
+            }
+          }
+          break;
         case DEVICE_PHT_BME280:
           {
             BME280 *nodeDevice = (BME280 *)temp->classPtr;
@@ -1270,6 +1297,20 @@ static void getHelperText(char* helperText, size_t lenText)
                 strlcat(helperText, "pressure_hPa,", lenText);
               if (nodeSetting->logTemperature)
                 strlcat(helperText, "pressure_degC,", lenText);
+            }
+          }
+          break;
+        case DEVICE_PRESSURE_BMP390:
+          {
+            struct_BMP390 *nodeSetting = (struct_BMP390 *)temp->configPtr;
+            if (nodeSetting->log)
+            {
+              if (nodeSetting->logPressure)
+                strlcat(helperText, "pressure_Pa,", lenText);
+              if (nodeSetting->logAltitude)
+                strlcat(helperText, "altitude_m,", lenText);
+              if (nodeSetting->logTemperature)
+                strlcat(helperText, "temp_degC,", lenText);
             }
           }
           break;

--- a/Firmware/OpenLog_Artemis/autoDetect.ino
+++ b/Firmware/OpenLog_Artemis/autoDetect.ino
@@ -726,18 +726,19 @@ void configureDevice(node * temp)
       //Nothing to configure
       break;
     case DEVICE_PRESSURE_BMP390:
-      DFRobot_BMP390L_I2C *sensor = (DFRobot_BMP390L_I2C *)temp->classPtr;
-      /**
-      * 6 commonly used sampling modes that allows users to configure easily, mode:
-      *      eUltraLowPrecision, Ultra-low precision, suitable for monitoring weather (lowest power consumption), the power is mandatory mode.
-      *      eLowPrecision, Low precision, suitable for random detection, power is normal mode
-      *      eNormalPrecision1, Normal precision 1, suitable for dynamic detection on handheld devices (e.g on mobile phones), power is normal mode.
-      *      eNormalPrecision2, Normal precision 2, suitable for drones, power is normal mode.
-      *      eHighPrecision, High precision, suitable for low-power handled devices (e.g mobile phones), power is in normal mode.
-      *      eUltraPrecision, Ultra-high precision, suitable for indoor navigation, its acquisition rate will be extremely low, and the acquisition cycle is 1000 ms.
-      */
-      sensor->setSamplingMode(sensor.eNormalPrecision1);
-
+      {
+        DFRobot_BMP390L_I2C *sensor = (DFRobot_BMP390L_I2C *)temp->classPtr;
+        /**
+        * 6 commonly used sampling modes that allows users to configure easily, mode:
+        *      eUltraLowPrecision, Ultra-low precision, suitable for monitoring weather (lowest power consumption), the power is mandatory mode.
+        *      eLowPrecision, Low precision, suitable for random detection, power is normal mode
+        *      eNormalPrecision1, Normal precision 1, suitable for dynamic detection on handheld devices (e.g on mobile phones), power is normal mode.
+        *      eNormalPrecision2, Normal precision 2, suitable for drones, power is normal mode.
+        *      eHighPrecision, High precision, suitable for low-power handled devices (e.g mobile phones), power is in normal mode.
+        *      eUltraPrecision, Ultra-high precision, suitable for indoor navigation, its acquisition rate will be extremely low, and the acquisition cycle is 1000 ms.
+        */
+        sensor->setSamplingMode(sensor->eNormalPrecision1);
+      }
       break;
     case DEVICE_PHT_BME280:
       //Nothing to configure

--- a/Firmware/OpenLog_Artemis/autoDetect.ino
+++ b/Firmware/OpenLog_Artemis/autoDetect.ino
@@ -726,7 +726,18 @@ void configureDevice(node * temp)
       //Nothing to configure
       break;
     case DEVICE_PRESSURE_BMP390:
-      //Nothing to configure
+      DFRobot_BMP390L_I2C *sensor = (DFRobot_BMP390L_I2C *)temp->classPtr;
+      /**
+      * 6 commonly used sampling modes that allows users to configure easily, mode:
+      *      eUltraLowPrecision, Ultra-low precision, suitable for monitoring weather (lowest power consumption), the power is mandatory mode.
+      *      eLowPrecision, Low precision, suitable for random detection, power is normal mode
+      *      eNormalPrecision1, Normal precision 1, suitable for dynamic detection on handheld devices (e.g on mobile phones), power is normal mode.
+      *      eNormalPrecision2, Normal precision 2, suitable for drones, power is normal mode.
+      *      eHighPrecision, High precision, suitable for low-power handled devices (e.g mobile phones), power is in normal mode.
+      *      eUltraPrecision, Ultra-high precision, suitable for indoor navigation, its acquisition rate will be extremely low, and the acquisition cycle is 1000 ms.
+      */
+      sensor->setSamplingMode(sensor.eNormalPrecision1);
+
       break;
     case DEVICE_PHT_BME280:
       //Nothing to configure

--- a/Firmware/OpenLog_Artemis/menuAttachedDevices.ino
+++ b/Firmware/OpenLog_Artemis/menuAttachedDevices.ino
@@ -306,6 +306,9 @@ void menuAttachedDevices()
           case DEVICE_PRESSURE_LPS25HB:
             SerialPrintf3("%s LPS25HB Pressure Sensor %s\r\n", strDeviceMenu, strAddress);
             break;
+          case DEVICE_PRESSURE_BMP390:
+            SerialPrintf3("%s BMP390 Pressure/Temperature Sensor %s\r\n", strDeviceMenu, strAddress);
+            break;
           case DEVICE_PHT_BME280:
             SerialPrintf3("%s BME280 Pressure/Humidity/Temp (PHT) Sensor %s\r\n", strDeviceMenu, strAddress);
             break;
@@ -712,6 +715,63 @@ void menuConfigure_BME280(void *configPtr)
       else if (incoming == '4')
         sensorSetting->logAltitude ^= 1;
       else if (incoming == '5')
+        sensorSetting->logTemperature ^= 1;
+      else if (incoming == 'x')
+        break;
+      else if (incoming == STATUS_GETBYTE_TIMEOUT)
+        break;
+      else
+        printUnknown(incoming);
+    }
+    else if (incoming == 'x')
+      break;
+    else if (incoming == STATUS_GETBYTE_TIMEOUT)
+      break;
+    else
+      printUnknown(incoming);
+  }
+}
+
+void menuConfigure_BMP390(void *configPtr)
+{
+  struct_BMP390 *sensorSetting = (struct_BMP390*)configPtr;
+
+  while (1)
+  {
+    SerialPrintln(F(""));
+    SerialPrintln(F("Menu: Configure BMP390 Pressure/Temperature Sensor"));
+
+    SerialPrint(F("1) Sensor Logging: "));
+    if (sensorSetting->log == true) SerialPrintln(F("Enabled"));
+    else SerialPrintln(F("Disabled"));
+
+    if (sensorSetting->log == true)
+    {
+      SerialPrint(F("2) Log Pressure: "));
+      if (sensorSetting->logPressure == true) SerialPrintln(F("Enabled"));
+      else SerialPrintln(F("Disabled"));
+
+      SerialPrint(F("3) Log Altitude: "));
+      if (sensorSetting->logAltitude == true) SerialPrintln(F("Enabled"));
+      else SerialPrintln(F("Disabled"));
+
+      SerialPrint(F("4) Log Temperature: "));
+      if (sensorSetting->logTemperature == true) SerialPrintln(F("Enabled"));
+      else SerialPrintln(F("Disabled"));
+    }
+    SerialPrintln(F("x) Exit"));
+
+    byte incoming = getByteChoice(menuTimeout); //Timeout after x seconds
+
+    if (incoming == '1')
+      sensorSetting->log ^= 1;
+    else if (sensorSetting->log == true)
+    {
+      if (incoming == '2')
+        sensorSetting->logPressure ^= 1;
+      else if (incoming == '3')
+        sensorSetting->logAltitude ^= 1;
+      else if (incoming == '4')
         sensorSetting->logTemperature ^= 1;
       else if (incoming == 'x')
         break;

--- a/Firmware/OpenLog_Artemis/nvm.ino
+++ b/Firmware/OpenLog_Artemis/nvm.ino
@@ -594,6 +594,15 @@ void recordDeviceSettingsToFile()
             settingsFile.println((String)base + "logTemperature=" + nodeSetting->logTemperature);
           }
           break;
+        case DEVICE_PRESSURE_BMP390:
+          {
+            struct_BMP390 *nodeSetting = (struct_BMP390 *)temp->configPtr;
+            settingsFile.println((String)base + "log=" + nodeSetting->log);
+            settingsFile.println((String)base + "logPressure=" + nodeSetting->logPressure);
+            settingsFile.println((String)base + "logAltitude=" + nodeSetting->logAltitude);
+            settingsFile.println((String)base + "logTemperature=" + nodeSetting->logTemperature);
+          }
+          break;
         case DEVICE_PHT_BME280:
           {
             struct_BME280 *nodeSetting = (struct_BME280 *)temp->configPtr;
@@ -1074,6 +1083,21 @@ bool parseDeviceLine(char* str) {
             nodeSetting->log = d;
           else if (strcmp(deviceSettingName, "logPressure") == 0)
             nodeSetting->logPressure = d;
+          else if (strcmp(deviceSettingName, "logTemperature") == 0)
+            nodeSetting->logTemperature = d;
+          else
+            SerialPrintf2("Unknown device setting: %s\r\n", deviceSettingName);
+        }
+        break;
+      case DEVICE_PRESSURE_BMP390:
+        {
+          struct_BMP390 *nodeSetting = (struct_BMP390 *)deviceConfigPtr; //Create a local pointer that points to same spot as node does
+          if (strcmp(deviceSettingName, "log") == 0)
+            nodeSetting->log = d;
+          else if (strcmp(deviceSettingName, "logPressure") == 0)
+            nodeSetting->logPressure = d;
+          else if (strcmp(deviceSettingName, "logAltitude") == 0)
+            nodeSetting->logAltitude = d;
           else if (strcmp(deviceSettingName, "logTemperature") == 0)
             nodeSetting->logTemperature = d;
           else

--- a/Firmware/OpenLog_Artemis/settings.h
+++ b/Firmware/OpenLog_Artemis/settings.h
@@ -11,6 +11,7 @@ typedef enum
   DEVICE_TEMPERATURE_TMP117,
   DEVICE_PRESSURE_MS5637,
   DEVICE_PRESSURE_LPS25HB,
+  DEVICE_PRESSURE_BMP390,
   DEVICE_PHT_BME280,
   DEVICE_UV_VEML6075,
   DEVICE_VOC_CCS811,
@@ -166,6 +167,14 @@ struct struct_CCS811 {
   bool log = true;
   bool logTVOC = true;
   bool logCO2 = true;
+  unsigned long powerOnDelayMillis = minimumQwiicPowerOnDelay; // Wait for at least this many millis before communicating with this device. Increase if required!
+};
+
+struct struct_BMP390 {
+  bool log = true;
+  bool logPressure = true;
+  bool logAltitude = true;
+  bool logTemperature = true;
   unsigned long powerOnDelayMillis = minimumQwiicPowerOnDelay; // Wait for at least this many millis before communicating with this device. Increase if required!
 };
 

--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ The OpenLog Artemis automatically scans, detects, configures, and logs various Q
 * [ADS122C04 ADC PT100 Sensor](https://www.sparkfun.com/products/16770)
 * [Qwiic Mux](https://www.sparkfun.com/products/16784) allowing for the chaining of up to 64 unique buses!
 * [Pulse Oximeter and Heart Rate Sensor](https://www.sparkfun.com/products/15219) (requires exclusive use of pins 32 and 11)
+* [BMP390 Barometric Pressure, Temperature and Altimeter Sensor](https://www.adafruit.com/product/4816)
 * More boards are being added all the time!
 
 Very low power logging is supported. OpenLog Artemis can be configured to take readings at 500 times a second, or as slow as 1 reading every 24 hours. You choose! When there is more than 2 seconds between readings OLA will automatically power down itself and the sensors on the bus resulting in a sleep current of approximately 18uA. This means a normal [2Ah battery](https://www.sparkfun.com/products/13855) will enable logging for more than 4,000 days! OpenLog Artemis has built-in LiPo charging set at 450mA/hr.

--- a/SENSOR_UNITS.md
+++ b/SENSOR_UNITS.md
@@ -360,3 +360,12 @@ Extended status:
 -4: Pressing too hard  
 -5: Object other than finger detected  
 -6: Excessive finger motion  
+
+---
+## BMP390 atmospheric sensor
+
+| []() | | |
+|---|---|---|
+| Pressure | pressure_Pa | Pascals |
+| Altitude | altitude_m | m |
+| Temperature | temp_degC | Degrees Centigrade |


### PR DESCRIPTION
One more pull request to support BMP390. For now only on address 0x77 because the library used uses an unconventional method for address selection. Library used is: https://github.com/DFRobot/DFRobot_BMP3XX

I hope this will work find with the muxer as well.. I did not put effort into this. I am a bit worried because of the code I found for the BME280: "MultiplexerBegin confuses the BME280, so let's check if one is connected first"

So maybe this will not get pulled, but at least it might be a good starting point for someone in the future.