### PR TITLE
Release candidate

### DIFF
--- a/Firmware/OpenLog_Artemis/OpenLog_Artemis.ino
+++ b/Firmware/OpenLog_Artemis/OpenLog_Artemis.ino
@@ -327,6 +327,7 @@ bool takeReading = true; //Goes true when enough time has passed between reading
 bool sleepAfterRead = false; //Used to keep the code awake for at least minimumAwakeTimeMillis
 const uint64_t maxUsBeforeSleep = 2000000ULL; //Number of us between readings before sleep is activated.
 const byte menuTimeout = 15; //Menus will exit/timeout after this number of seconds
+const int sdCardMenuTimeout = 60; // sdCard menu will exit/timeout after this number of seconds
 volatile static bool stopLoggingSeen = false; //Flag to indicate if we should stop logging
 uint64_t qwiicPowerOnTime = 0; //Used to delay after Qwiic power on to allow sensors to power on, then answer autodetect
 unsigned long qwiicPowerOnDelayMillis; //Wait for this many milliseconds after turning on the Qwiic power before attempting to communicate with Qwiic devices

--- a/Firmware/OpenLog_Artemis/menuDebug.ino
+++ b/Firmware/OpenLog_Artemis/menuDebug.ino
@@ -21,6 +21,8 @@ void menuDebug()
     if (settings.openMenuWithPrintable == true) SerialPrintln(F("Yes"));
     else SerialPrintln(F("No"));
 
+    SerialPrintln(F("5) Reboot the logger "));
+
     SerialPrintln(F("x) Exit"));
 
     byte incoming = getByteChoice(menuTimeout); //Timeout after x seconds
@@ -57,6 +59,16 @@ void menuDebug()
     else if (incoming == '4')
     {
       settings.openMenuWithPrintable ^= 1;
+    }
+    else if (incoming == '5')
+    {
+        SerialPrint(F("Are you sure? Press 'y' to confirm: "));
+        byte bContinue = getByteChoice(menuTimeout);
+        if (bContinue == 'y')
+        {
+          SerialPrintln(F("y"));
+          resetArtemis();
+        }
     }
     else if (incoming == 'x')
       break;

--- a/Firmware/OpenLog_Artemis/menuMain.ino
+++ b/Firmware/OpenLog_Artemis/menuMain.ino
@@ -109,14 +109,18 @@ void menuMain(bool alwaysOpen)
         
         if (online.dataLogging == true)
         {
-          strcpy(sensorDataFileName, findNextAvailableLog(settings.nextDataLogNumber, "dataLog"));
+          // Check if the current datafile was deleted
+          if (sd.exists(sensorDataFileName) == false)
+            strcpy(sensorDataFileName, findNextAvailableLog(settings.nextDataLogNumber, "dataLog"));
           beginDataLogging(); //180ms
           if (settings.showHelperText == true) 
             printHelperText(OL_OUTPUT_SERIAL | OL_OUTPUT_SDCARD); //printHelperText to terminal and sensor file
         }
         if (online.serialLogging == true)
         {
-          strcpy(serialDataFileName, findNextAvailableLog(settings.nextSerialLogNumber, "serialLog"));
+          // Check if the current serial file was deleted
+          if (sd.exists(serialDataFileName) == false)
+            strcpy(serialDataFileName, findNextAvailableLog(settings.nextSerialLogNumber, "serialLog"));
           beginSerialLogging();
         }
       }

--- a/Firmware/OpenLog_Artemis/menuMain.ino
+++ b/Firmware/OpenLog_Artemis/menuMain.ino
@@ -103,7 +103,7 @@ void menuMain(bool alwaysOpen)
   
         SerialPrintln(F(""));
         SerialPrintln(F(""));
-        sdCardMenu(); // Located in zmodem.ino
+        sdCardMenu(sdCardMenuTimeout); // Located in zmodem.ino
         SerialPrintln(F(""));
         SerialPrintln(F(""));
         

--- a/Firmware/OpenLog_Artemis/zmodem.ino
+++ b/Firmware/OpenLog_Artemis/zmodem.ino
@@ -201,10 +201,12 @@ int count_files(int *file_count, long *byte_count)
   return 0;
 }
 
-void sdCardMenu(void)
+void sdCardMenu(int numberOfSeconds)
 {
   sdCardHelp(); // Display the help
   
+  unsigned long startTime = millis();
+
   bool keepGoing = true;
   
   while (keepGoing)
@@ -221,6 +223,7 @@ void sdCardMenu(void)
     {
       if (DSERIAL->available() > 0)
       {
+        startTime = millis(); // reset the start time if we receive a char
         c = DSERIAL->read();
         if ((c == 8 or c == 127) && strlen(cmd) > 0) cmd[strlen(cmd)-1] = 0;
         if (c == '\n' || c == '\r') break;
@@ -236,6 +239,11 @@ void sdCardMenu(void)
         // from Serial
         checkBattery();
         delay(1);
+        if ( (millis() - startTime) / 1000 >= numberOfSeconds)
+        {
+          SerialPrintln(F("No user input received."));
+          return;
+        }        
       }
     }
      
@@ -459,5 +467,7 @@ void sdCardMenu(void)
     {
       keepGoing = false;
     }
+    
+    startTime = millis(); // reset the start time after commanded action completes
   }
 }


### PR DESCRIPTION
This version contains 3 changes (in 3 commits):
1.	Reset option added to debug menu (via resetArtemis)
We occasionally get in a state where something in the software is out of whack.  We have remote access to our system, but physical access is much more difficult.  The ability to reset from the menu would be a significant benefit.  We might even use this feature to do daily resets to assure stability.
2.	Turned off automatic increment of file number after using SD card menu (issue #140)
Having looked into this, the one thing a user can do from the SD card menu that affects files is to delete them.  In the existing (pre-modification) version, findNextAvailableLog is always called.  This has the effect of incrementing the file number.  The desired effect is to not increment the file number.  Since the user can interfere by deleting files, this new version checks to see if the current sensorDataFile/serialDataFile still exists.  If it was deleted, findNextAvailableLog is still called.  Otherwise it is not.
Although this brings up the question is this what should happen?  The routine findNextAvailableLog begins its search at settings.nextDataLogNumber.  If the user has deleted several (or all) data files, perhaps the search should begin at dataLogNumber 1.  This could take a long time if there are a lot of files, but maybe that’s the right thing to do if files have been deleted.  Perhaps that check should be done in setup too.  Often I will take the SD card out, copy the data files, delete them, and put the card back in.  How else can the file number be reset besides manually editing the settings file?
3.	Added timeout to SD card menu
We occasionally get stuck in the SD card menu.  We do automated file downloads via a Bluetooth link.  If we lose connectivity while in the SD card menu sampling does not resume until connectivity can be re-established and the remote system recognizes the problem and fixes it.  (Connectivity loss is on purpose because the sensor sometimes goes under water.)  A timeout in the SD card menu will allow sampling to continue.
