### PR TITLE
Support ICM 20948

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,7 +32,8 @@ $RECYCLE.BIN/
 .LSOverride
 
 # Icon must ends with two \r.
-Icon
+Icon
+
 
 # Thumbnails
 ._*
@@ -40,3 +41,6 @@ Icon
 # Files that might appear on external disk
 .Spotlight-V100
 .Trashes
+
+#vscode
+.vscode

--- a/ADDING_SENSORS.md
+++ b/ADDING_SENSORS.md
@@ -22,7 +22,7 @@ First up, please target any commits at the _**release_candidate**_ branch, so th
 
 - This is where the sensor readings are actually read. [Add a case for the new sensor](https://github.com/sparkfun/OpenLog_Artemis/commit/2a26acd279fa93cfe84f1bc518c0e7a041b3bc44#diff-fba25af49a58a7a24fb75cb34321e25dd4a94a9d3515ac051fcaa4502e444f7fR725-R798)
 
-### printHelperText
+### getHelperText
 
 - [Add helper text for the sensor readings](https://github.com/sparkfun/OpenLog_Artemis/commit/2a26acd279fa93cfe84f1bc518c0e7a041b3bc44#diff-fba25af49a58a7a24fb75cb34321e25dd4a94a9d3515ac051fcaa4502e444f7fR1132-R1165)
 

--- a/Firmware/OpenLog_Artemis/OpenLog_Artemis.ino
+++ b/Firmware/OpenLog_Artemis/OpenLog_Artemis.ino
@@ -145,6 +145,9 @@
     Add Tony Whipple's PR #146 - thank you @whipple63
     Add support for the ISM330DHCX, MMC5983MA, KX134 and ADS1015
     Resolve issue #87
+
+  v2.6:
+    Add support for ICM-20948 automatic detection logging via I2C
 */
 
 const int FIRMWARE_VERSION_MAJOR = 2;

--- a/Firmware/OpenLog_Artemis/Sensors.ino
+++ b/Firmware/OpenLog_Artemis/Sensors.ino
@@ -243,6 +243,10 @@ void gatherDeviceValues(char * sdOutputData, size_t lenData)
             //No data to print for a mux
           }
           break;
+        case DEVICE_IMU_ICM20948:
+          {
+            //TODO: Add support for ICM20948
+          }
         case DEVICE_LOADCELL_NAU7802:
           {
             NAU7802 *nodeDevice = (NAU7802 *)temp->classPtr;

--- a/Firmware/OpenLog_Artemis/Sensors.ino
+++ b/Firmware/OpenLog_Artemis/Sensors.ino
@@ -243,10 +243,6 @@ void gatherDeviceValues(char * sdOutputData, size_t lenData)
             //No data to print for a mux
           }
           break;
-        case DEVICE_IMU_ICM20948:
-          {
-            //TODO: Add support for ICM20948
-          }
         case DEVICE_LOADCELL_NAU7802:
           {
             NAU7802 *nodeDevice = (NAU7802 *)temp->classPtr;
@@ -1093,6 +1089,55 @@ void gatherDeviceValues(char * sdOutputData, size_t lenData)
             }
           }
           break;
+        case DEVICE_IMU_ICM20948:
+          {
+            ICM_20948_I2C *nodeDevice = (ICM_20948_I2C *)temp->classPtr;
+            struct_ICM20948 *nodeSetting = (struct_ICM20948 *)temp->configPtr;
+            if (nodeSetting->log == true)
+            {
+              static bool dataReady;
+              if ((nodeSetting->logAccel) || (nodeSetting->logGyro) || (nodeSetting->logMag))
+              {
+                // Check if both gyroscope and accelerometer data is available.
+                dataReady = nodeDevice->dataReady();
+                if( dataReady )
+                {
+                  nodeDevice->getAGMT();
+                }
+              }
+              if (nodeSetting->logAccel)
+              {
+                olaftoa(nodeDevice->accX(), tempData1, 2, sizeof(tempData1) / sizeof(char));
+                olaftoa(nodeDevice->accY(), tempData2, 2, sizeof(tempData2) / sizeof(char));
+                olaftoa(nodeDevice->accZ(), tempData3, 2, sizeof(tempData3) / sizeof(char));
+                sprintf(tempData, "%s,%s,%s,", tempData1, tempData2, tempData3);
+                strlcat(sdOutputData, tempData, lenData);
+              }
+              if (nodeSetting->logGyro)
+              {
+                olaftoa(nodeDevice->gyrX(), tempData1, 2, sizeof(tempData1) / sizeof(char));
+                olaftoa(nodeDevice->gyrY(), tempData2, 2, sizeof(tempData2) / sizeof(char));
+                olaftoa(nodeDevice->gyrZ(), tempData3, 2, sizeof(tempData3) / sizeof(char));
+                sprintf(tempData, "%s,%s,%s,", tempData1, tempData2, tempData3);
+                strlcat(sdOutputData, tempData, lenData);
+              }
+              if (nodeSetting->logMag)
+              {
+                olaftoa(nodeDevice->magX(), tempData1, 2, sizeof(tempData1) / sizeof(char));
+                olaftoa(nodeDevice->magY(), tempData2, 2, sizeof(tempData2) / sizeof(char));
+                olaftoa(nodeDevice->magZ(), tempData3, 2, sizeof(tempData3) / sizeof(char));
+                sprintf(tempData, "%s,%s,%s,", tempData1, tempData2, tempData3);
+                strlcat(sdOutputData, tempData, lenData);
+              }
+              if (nodeSetting->logTemp)
+              {
+                olaftoa(nodeDevice->temp(), tempData1, 2, sizeof(tempData1) / sizeof(char));
+                sprintf(tempData, "%s,", tempData1);
+                strlcat(sdOutputData, tempData, lenData);
+              }
+            }
+          }
+          break;
         case DEVICE_ISM330DHCX:
           {
             SparkFun_ISM330DHCX *nodeDevice = (SparkFun_ISM330DHCX *)temp->classPtr;
@@ -1367,6 +1412,22 @@ static void getHelperText(char* helperText, size_t lenText)
         case DEVICE_MULTIPLEXER:
           {
             //No data to print for a mux
+          }
+          break;
+        case DEVICE_IMU_ICM20948:
+          {
+            struct_ICM20948 *nodeSetting = (struct_ICM20948 *)temp->configPtr;
+            if (nodeSetting->log)
+            {
+              if (nodeSetting->logAccel)
+                strlcat(helperText, "aX,aY,aZ,", lenText);
+              if (nodeSetting->logGyro)
+                strlcat(helperText, "gX,gY,gZ,", lenText);
+              if (nodeSetting->logMag)
+                strlcat(helperText, "mX,mY,mZ,", lenText);
+              if (nodeSetting->logTemp)
+                strlcat(helperText, "imu_degC,", lenText);
+            }
           }
           break;
         case DEVICE_LOADCELL_NAU7802:

--- a/Firmware/OpenLog_Artemis/autoDetect.ino
+++ b/Firmware/OpenLog_Artemis/autoDetect.ino
@@ -123,6 +123,12 @@ bool addDevice(deviceType_e deviceType, uint8_t address, uint8_t muxAddress, uin
         temp->configPtr = new struct_multiplexer;
       }
       break;
+    case DEVICE_IMU_ICM20948:
+      {
+        temp->classPtr = new ICM_20948_I2C;
+        temp->configPtr = new struct_ICM20948;
+      }
+      break;
     case DEVICE_LOADCELL_NAU7802:
       {
         temp->classPtr = new NAU7802;
@@ -352,6 +358,21 @@ bool beginQwiicDevices()
           struct_multiplexer *nodeSetting = (struct_multiplexer *)temp->configPtr; //Create a local pointer that points to same spot as node does
           if (nodeSetting->powerOnDelayMillis > qwiicPowerOnDelayMillis) qwiicPowerOnDelayMillis = nodeSetting->powerOnDelayMillis; // Increase qwiicPowerOnDelayMillis if required
           temp->online = tempDevice->begin(temp->address, qwiic); //Address, Wire port
+        }
+        break;
+      case DEVICE_IMU_ICM20948:
+        {
+          ICM_20948_I2C *tempDevice = (ICM_20948_I2C *)temp->classPtr;
+          struct_ICM20948 *nodeSetting = (struct_ICM20948 *)temp->configPtr; //Create a local pointer that points to same spot as node does
+          if (nodeSetting->powerOnDelayMillis > qwiicPowerOnDelayMillis) qwiicPowerOnDelayMillis = nodeSetting->powerOnDelayMillis; // Increase qwiicPowerOnDelayMillis if required
+          if (temp->address == 0x69) 
+          {
+            temp->online = (tempDevice->begin(qwiic, 1) == ICM_20948_Stat_Ok); //Wire port, AD0_VAL
+          }
+          else
+          {
+            temp->online = (tempDevice->begin(qwiic, 0) == ICM_20948_Stat_Ok); //Wire port, AD0_VAL
+          }
         }
         break;
       case DEVICE_LOADCELL_NAU7802:
@@ -1017,6 +1038,9 @@ FunctionPointer getConfigFunctionPtr(uint8_t nodeNumber)
     case DEVICE_MULTIPLEXER:
       ptr = (FunctionPointer)menuConfigure_Multiplexer;
       break;
+    case DEVICE_IMU_ICM20948:
+      ptr = (FunctionPointer)menuConfigure_ICM20948;
+      break;
     case DEVICE_LOADCELL_NAU7802:
       ptr = (FunctionPointer)menuConfigure_NAU7802;
       break;
@@ -1493,9 +1517,8 @@ deviceType_e testDevice(uint8_t i2cAddress, uint8_t muxAddress, uint8_t portNumb
       {
         //Confidence high - Checks functionality
         ICM_20948_I2C sensor;
-        if (sensor.begin(qwiic, 1) == ICM_20948_Stat_Ok) //Wire port, AD0_VAL
-          return(DEVICE_ICM20948);
-        if ()
+        if (sensor.begin(qwiic, 0) == ICM_20948_Stat_Ok) //Wire port, AD0_VAL
+          return(DEVICE_IMU_ICM20948);
       }
     case 0x69:
       {
@@ -1505,8 +1528,7 @@ deviceType_e testDevice(uint8_t i2cAddress, uint8_t muxAddress, uint8_t portNumb
         //Confidence high - Checks functionality
         ICM_20948_I2C sensor1;
         if (sensor1.begin(qwiic, 1) == ICM_20948_Stat_Ok) //Wire port, AD0_VAL
-          return(DEVICE_ICM20948);
-        if ()
+          return(DEVICE_IMU_ICM20948);
       }
       break;
     case 0x6A:
@@ -1793,6 +1815,9 @@ const char* getDeviceName(deviceType_e deviceNumber)
   {
     case DEVICE_MULTIPLEXER:
       return "Multiplexer";
+      break;
+    case DEVICE_IMU_ICM20948:
+      return "IMU-ICM20948";
       break;
     case DEVICE_LOADCELL_NAU7802:
       return "LoadCell-NAU7802";

--- a/Firmware/OpenLog_Artemis/autoDetect.ino
+++ b/Firmware/OpenLog_Artemis/autoDetect.ino
@@ -1250,6 +1250,7 @@ void swap(struct node * a, struct node * b)
 #define ADR_VCNL4040 0x60
 #define ADR_SCD30 0x61
 #define ADR_MCP9600 0x60 //0x60 to 0x67
+#define ADR_ICM20948 0x69 //Alternate: 0x68
 #define ADR_ISM330DHCX 0x6A //Alternate: 0x6B
 #define ADR_QWIIC_BUTTON 0x6F //But can be any address... Limit the range to 0x68-0x6F
 #define ADR_MULTIPLEXER 0x70 //0x70 to 0x77
@@ -1489,11 +1490,23 @@ deviceType_e testDevice(uint8_t i2cAddress, uint8_t muxAddress, uint8_t portNumb
       }
       break;
     case 0x68:
+      {
+        //Confidence high - Checks functionality
+        ICM_20948_I2C sensor;
+        if (sensor.begin(qwiic, 1) == ICM_20948_Stat_Ok) //Wire port, AD0_VAL
+          return(DEVICE_ICM20948);
+        if ()
+      }
     case 0x69:
       {
         QwiicButton sensor;
         if (sensor.begin(i2cAddress, qwiic) == true) //Address, Wire port
           return (DEVICE_QWIIC_BUTTON);
+        //Confidence high - Checks functionality
+        ICM_20948_I2C sensor1;
+        if (sensor1.begin(qwiic, 1) == ICM_20948_Stat_Ok) //Wire port, AD0_VAL
+          return(DEVICE_ICM20948);
+        if ()
       }
       break;
     case 0x6A:

--- a/Firmware/OpenLog_Artemis/menuAttachedDevices.ino
+++ b/Firmware/OpenLog_Artemis/menuAttachedDevices.ino
@@ -288,6 +288,9 @@ void menuAttachedDevices()
           case DEVICE_LOADCELL_NAU7802:
             SerialPrintf3("%s NAU7802 Weight Sensor %s\r\n", strDeviceMenu, strAddress);
             break;
+          case DEVICE_IMU_ICM20948:
+            SerialPrintf3("%s ICM20948 IMU %s\r\n", strDeviceMenu, strAddress);
+            break;
           case DEVICE_DISTANCE_VL53L1X:
             SerialPrintf3("%s VL53L1X Distance Sensor %s\r\n", strDeviceMenu, strAddress);
             break;
@@ -473,6 +476,13 @@ void menuAttachedDevices()
     else
       printUnknown(nodeNumber);
   }
+}
+
+void menuConfigure_ICM20948()
+{
+  SerialPrintln(F(""));
+  SerialPrintln(F("Menu: Configure ICM20948 not yet implemented"));
+  //TODO: Implement this
 }
 
 void menuConfigure_QwiicBus()

--- a/Firmware/OpenLog_Artemis/nvm.ino
+++ b/Firmware/OpenLog_Artemis/nvm.ino
@@ -515,6 +515,16 @@ void recordDeviceSettingsToFile()
             //settingsFile.println((String)base + "log=" + nodeSetting->log);
           }
           break;
+        case DEVICE_IMU_ICM20948:
+          {
+            struct_ICM20948 *nodeSetting = (struct_ICM20948 *)temp->configPtr;
+            settingsFile.println((String)base + "log=" + nodeSetting->log);
+            settingsFile.println((String)base + "logAccel=" + nodeSetting->logAccel);
+            settingsFile.println((String)base + "logGyro=" + nodeSetting->logGyro);
+            settingsFile.println((String)base + "logMag=" + nodeSetting->logMag);
+            settingsFile.println((String)base + "logTemp=" + nodeSetting->logTemp);
+          }
+          break;
         case DEVICE_LOADCELL_NAU7802:
           {
             struct_NAU7802 *nodeSetting = (struct_NAU7802 *)temp->configPtr;
@@ -995,6 +1005,25 @@ bool parseDeviceLine(char* str) {
       case DEVICE_MULTIPLEXER:
         {
           SerialPrintln(F("There are no known settings for a multiplexer to load."));
+        }
+        break;
+      case DEVICE_IMU_ICM20948:
+        {
+          struct_ICM20948 *nodeSetting = (struct_ICM20948 *)deviceConfigPtr;
+
+          //Apply the appropriate settings
+          if (strcmp(deviceSettingName, "log") == 0)
+            nodeSetting->log = d;
+          else if (strcmp(deviceSettingName, "logAccel") == 0)
+            nodeSetting->logAccel = d;
+          else if (strcmp(deviceSettingName, "logGyro") == 0)
+            nodeSetting->logGyro = d;
+          else if (strcmp(deviceSettingName, "logMag") == 0)
+            nodeSetting->logMag = d;
+          else if (strcmp(deviceSettingName, "logTemp") == 0)
+            nodeSetting->logTemp = d;
+          else
+            SerialPrintf2("Unknown device setting: %s\r\n", deviceSettingName);
         }
         break;
       case DEVICE_LOADCELL_NAU7802:

--- a/Firmware/OpenLog_Artemis/settings.h
+++ b/Firmware/OpenLog_Artemis/settings.h
@@ -4,6 +4,7 @@
 typedef enum
 {
   DEVICE_MULTIPLEXER = 0,
+  DEVICE_IMU_ICM20948,
   DEVICE_LOADCELL_NAU7802,
   DEVICE_DISTANCE_VL53L1X,
   DEVICE_GPS_UBLOX,
@@ -90,6 +91,16 @@ struct struct_LPS25HB {
   bool log = true;
   bool logPressure = true;
   bool logTemperature = true;
+  unsigned long powerOnDelayMillis = minimumQwiicPowerOnDelay; // Wait for at least this many millis before communicating with this device. Increase if required!
+};
+
+
+struct struct_ICM20948 {
+  bool log = true;
+  bool logAccel = true;
+  bool logGyro = true;
+  bool logMag = true;
+  bool logTemp = true;
   unsigned long powerOnDelayMillis = minimumQwiicPowerOnDelay; // Wait for at least this many millis before communicating with this device. Increase if required!
 };
 

--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ The OpenLog Artemis automatically scans, detects, configures, and logs various Q
 * [MMC5983MA Magnetometer](https://www.sparkfun.com/products/19921)
 * [KX134 Accelerometer](https://www.sparkfun.com/products/17589)
 * [ADS1015 ADC](https://www.sparkfun.com/products/15334)
+* [ICM20948 IMU](https://www.sparkfun.com/products/15335)
 
 Very low power logging is supported. OpenLog Artemis can be configured to take readings at 500 times a second, or as slow as 1 reading every 24 hours. You choose! When there is more than 2 seconds between readings OLA will automatically power down itself and the sensors on the bus resulting in a sleep current of approximately 18uA. This means a normal [2Ah battery](https://www.sparkfun.com/products/13855) will enable logging for more than 4,000 days! OpenLog Artemis has built-in LiPo charging set at 450mA/hr.
 


### PR DESCRIPTION
Added support for ICM 20948 auto detection and logging of accel, gyro, mag and temp via I2C.

Full disclosure: This is relatively untested, but it appears to work as expected after connecting a 20948 sensor via the MUX board and firing up the serial monitor.