### PR TITLE
Added SCD30 FRC calibration to config menu

### DIFF
--- a/COMPILE_BINARY.md
+++ b/COMPILE_BINARY.md
@@ -107,6 +107,11 @@ Navigate to the `Extras` folder in the Zip file. Copy the `UartPower3.zip` file.
 C:\Users\<Your_User>\AppData\Local\Arduino15\packages\SparkFun\hardware\apollo3
 ```
 
+On Linux machines, this is (usually):
+```
+/home/<Your_User>/.arduino15/packages/SparkFun/hardware/apollo3/
+```
+
 Unzip it (Extract All files)
 
 **Close the Arduino IDE**
@@ -153,7 +158,7 @@ The extra code prevents badness when the Artemis goes into deep sleep
 Open the following file:
 
 ```
-C:\Users\<Your_User>\Documents\Arduino\libraries\SparkFun_ICM-20948_ArduinoLibrary\src\util\ICM_20948_C.h
+C:\Users\<Your_User>\Documents\Arduino\libraries\SparkFun_9DoF_IMU_Breakout_-_ICM_20948_-_Arduino_Library\src\util\ICM_20948_C.h
 ```
 
 Uncomment the following line (29):

--- a/Firmware/OpenLog_Artemis/autoDetect.ino
+++ b/Firmware/OpenLog_Artemis/autoDetect.ino
@@ -791,10 +791,18 @@ void configureDevice(node * temp)
         SCD30 *sensor = (SCD30 *)temp->classPtr;
         struct_SCD30 *sensorSetting = (struct_SCD30 *)temp->configPtr;
 
+        //Apply one-off calibrations
+        if(sensorSetting->applyCalibrationConcentration)
+        {
+          sensor->setForcedRecalibrationFactor(sensorSetting->calibrationConcentration);
+          sensorSetting->applyCalibrationConcentration = false;
+        }
+
         sensor->setMeasurementInterval(sensorSetting->measurementInterval);
         sensor->setAltitudeCompensation(sensorSetting->altitudeCompensation);
         sensor->setAmbientPressure(sensorSetting->ambientPressure);
         //sensor->setTemperatureOffset(sensorSetting->temperatureOffset);
+
       }
       break;
     case DEVICE_PHT_MS8607:

--- a/Firmware/OpenLog_Artemis/menuAttachedDevices.ino
+++ b/Firmware/OpenLog_Artemis/menuAttachedDevices.ino
@@ -1610,6 +1610,7 @@ void menuConfigure_SCD30(void *configPtr)
       SerialPrintf2("6) Set Altitude Compensation: %d\r\n", sensorSetting->altitudeCompensation);
       SerialPrintf2("7) Set Ambient Pressure: %d\r\n", sensorSetting->ambientPressure);
       SerialPrintf2("8) Set Temperature Offset: %d\r\n", sensorSetting->temperatureOffset);
+      SerialPrintln(F("9) Set FRC Calibration CO2"));
     }
     SerialPrintln(F("x) Exit"));
 
@@ -1665,6 +1666,18 @@ void menuConfigure_SCD30(void *configPtr)
           sensorSetting->temperatureOffset = amt;
         else
           SerialPrintln(F("Error: Out of range"));
+      }
+      else if (incoming == '9')
+      {
+        SerialPrint(F("Enter Calibration CO2 in ppm (400 to 2000): "));
+        int amt = getNumber(menuTimeout); //x second timeout
+        if (amt < 400 || amt > 2000)
+          SerialPrintln(F("Error: Out of range"));
+        else
+        {
+          sensorSetting->calibrationConcentration = amt;
+          sensorSetting->applyCalibrationConcentration = true;
+        }
       }
       else if (incoming == 'x')
         break;

--- a/Firmware/OpenLog_Artemis/settings.h
+++ b/Firmware/OpenLog_Artemis/settings.h
@@ -211,10 +211,12 @@ struct struct_SCD30 {
   bool logCO2 = true;
   bool logHumidity = true;
   bool logTemperature = true;
+  bool applyCalibrationConcentration = false;
   int measurementInterval = 2; //2 seconds
   int altitudeCompensation = 0; //0 m above sea level
   int ambientPressure = 1000; //mBar STP (Toto, I have a feeling we're not in Boulder anymore)
   int temperatureOffset = 0; //C - Be careful not to overwrite the value on the sensor
+  int calibrationConcentration = 400; //ppm CO2 - Must be applied 2+ minutes after sensor running in chamber of calibration gas 
   unsigned long powerOnDelayMillis = 5000; // Wait for at least this many millis before communicating with this device
 };
 


### PR DESCRIPTION
This code exposes setForcedRecalibrationFactor() for the SCD30 in the device config menu level in order to apply FRC using CO2 calibration gas between 400ppm and 2000ppm.