### PR TITLE
Add Mode 1/2 option for LPS28DFW sensor with SD card persistence

### DIFF
--- a/Firmware/OpenLog_Artemis/autoDetect.ino
+++ b/Firmware/OpenLog_Artemis/autoDetect.ino
@@ -440,7 +440,7 @@ bool beginQwiicDevices()
           temp->online = tempDevice->begin(temp->address, qwiic) == LPS28DFW_OK;
           lps28dfw_md_t modeConfig =
           {
-              .fs  = LPS28DFW_1260hPa,    // Full scale range
+              .fs  = (nodeSetting->mode == 2) ? LPS28DFW_4000hPa : LPS28DFW_1260hPa,    // Full scale range
               .odr = LPS28DFW_ONE_SHOT,        // Output data rate
               .avg = LPS28DFW_4_AVG,      // Average filter
               .lpf = LPS28DFW_LPF_DISABLE // Low-pass filter

--- a/Firmware/OpenLog_Artemis/menuAttachedDevices.ino
+++ b/Firmware/OpenLog_Artemis/menuAttachedDevices.ino
@@ -873,6 +873,10 @@ void menuConfigure_LPS28DFW(void *configPtr)
       SerialPrint(F("3) Log Temperature: "));
       if (sensorSetting->logTemperature == true) SerialPrintln(F("Enabled"));
       else SerialPrintln(F("Disabled"));
+
+      SerialPrint(F("4) Toggle Pressure Range: "));
+      if (sensorSetting->mode == 1) SerialPrintln(F("Mode 1 (260 - 1260 hPa)"));
+      else SerialPrintln(F("Mode 2 (260 - 4000 hPa)"));
     }
     SerialPrintln(F("x) Exit"));
 
@@ -886,6 +890,13 @@ void menuConfigure_LPS28DFW(void *configPtr)
         sensorSetting->logPressure ^= 1;
       else if (incoming == '3')
         sensorSetting->logTemperature ^= 1;
+      else if (incoming == '4')               // <-- NEW: Mode toggle
+      {
+        if (sensorSetting->mode == 1) 
+            sensorSetting->mode = 2;
+        else 
+            sensorSetting->mode = 1;
+      }
       else if (incoming == 'x')
         break;
       else if (incoming == STATUS_GETBYTE_TIMEOUT)

--- a/Firmware/OpenLog_Artemis/nvm.ino
+++ b/Firmware/OpenLog_Artemis/nvm.ino
@@ -622,6 +622,7 @@ void recordDeviceSettingsToFile()
             settingsFile.println((String)base + "log=" + nodeSetting->log);
             settingsFile.println((String)base + "logPressure=" + nodeSetting->logPressure);
             settingsFile.println((String)base + "logTemperature=" + nodeSetting->logTemperature);
+            settingsFile.println((String)base + "mode=" + nodeSetting->mode);
           }
           break;
         case DEVICE_PHT_BME280:
@@ -1206,6 +1207,8 @@ bool parseDeviceLine(char* str) {
             nodeSetting->logPressure = d;
           else if (strcmp(deviceSettingName, "logTemperature") == 0)
             nodeSetting->logTemperature = d;
+          else if (strcmp(deviceSettingName, "mode") == 0)
+            nodeSetting->mode = d;
           else
             SerialPrintf2("Unknown device setting: %s\r\n", deviceSettingName);
         }

--- a/Firmware/OpenLog_Artemis/settings.h
+++ b/Firmware/OpenLog_Artemis/settings.h
@@ -101,6 +101,7 @@ struct struct_LPS28DFW {
   bool log = true;
   bool logPressure = true;
   bool logTemperature = true;
+  uint8_t mode = 1; //Allow selection of pressure mode 1 (260-1060 hPa) or mode 2 (260-4000 hPa)
   unsigned long powerOnDelayMillis = minimumQwiicPowerOnDelay; // Wait for at least this many millis before communicating with this device. Increase if required!
 };
 


### PR DESCRIPTION
Theses modifications allow for the user to select either Mode 1 (260-1260 hPa) or Mode 2 (260-4000 hPa) for the LPS28DFW Digital Barometer.  

The mode change has been routed through the menu configurations, the Qwiic Device autodetection and storage on the SD card via nvm.ino.  

I have tried my best to stay in line with they way the code currently functions including NOT storing the option to the onboard eeprom memory.  this means if the user power cycles the OLA without an SD card present, it will always revert back to mode 1.  

ERROR/Concern - the ST spec sheet lists the mode 2 range for the pressure sensor to be 260-4060 hPA however the libraries are setup for 260-4000 hPa.  I have used the 260-4000 hPa ranges.  I the libraries are adjusted, please find and replace 4000 with 4060 throughout. 

PLEASE NOTE this is my first contribution to public SW work and I am keen on code review, feedback, testing and verifications by others. 